### PR TITLE
Feat: Improve DevEx, and include data-files when publishing WebAPI 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,9 +21,10 @@
 	// "remoteUser": "vscode",
 
 	// Add the IDs of extensions you want installed when the container is created in the array below.
-	// "extensions": [
+	"extensions": [
 	// 	"typescript.ts",
 	// 	"json.json",
-	// 	"html.html"
-	// ]
+	// 	"html.html",
+		"ms-dotnettools.csharp"	
+	]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": ".NET Core Launch (web)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "${workspaceFolder}/src/dotnet/CarbonAware.WebApi/bin/Debug/net6.0/CarbonAware.WebApi.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}",
+      "stopAtEntry": false,
+      "serverReadyAction": {
+        "action": "openExternally",
+        "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
+      },
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "sourceFileMap": {
+        "/Views": "${workspaceFolder}/Views"
+      }
+    }
+
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,24 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "shell",
+      "args": [
+        "build",
+        // Ask dotnet build to generate full paths for file names.
+        "src/dotnet/CarbonAware.WebApi/",
+        // Do not generate summary otherwise it leads to duplicate errors in Problems panel
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "group": "build",
+      "presentation": {
+        "reveal": "silent"
+      },
+      "problemMatcher": "$msCompile"
+    }
+  ]
+}

--- a/src/dotnet/CarbonAware.WebApi/CarbonAware.WebApi.csproj
+++ b/src/dotnet/CarbonAware.WebApi/CarbonAware.WebApi.csproj
@@ -47,4 +47,12 @@
 		<Copy SourceFiles="@(DataFiles)" DestinationFolder="$(TargetDir)\data-files\" SkipUnchangedFiles="true" />
 	</Target>
 
+	<Target Name="CopyDataFilesForPublish" AfterTargets="AfterPublish">
+		<ItemGroup>
+			<DataFiles Include="$(ProjectDir)..\data\data-files\*.*" />
+		</ItemGroup>
+
+		<Copy SourceFiles="@(DataFiles)" DestinationFolder="$(PublishDir)\data-files\" SkipUnchangedFiles="true" />
+	</Target>
+
 </Project>


### PR DESCRIPTION
While upskilling on this repo, we made use of the following quick-tweaks locally:
1. Support of "F5-debugging" in VSCode with OmniSharp extension
2. Ensure the WebAPI Dockefile includes the data-files required by the Basic-Plugin