### PR TITLE
Revert "Temporary updates to the build yaml for comparison"

### DIFF
--- a/.github/workflows/build-webapi.yaml
+++ b/.github/workflows/build-webapi.yaml
@@ -88,40 +88,38 @@ jobs:
         run: |
           wget -t 5 --waitretry=5 ${DATA_ENDPOINT}
 
-# Commented specifically for merge due to new folder structure breaking (by design)
-# To be uncommented after merge.
-#  api-comparison:
-#      needs: container-dotnet-build
-#      runs-on: ubuntu-latest
-#      defaults:
-#        run:
-#          working-directory: ./src/CarbonAware.WebApi/src
-#      container:
-#        image: mcr.microsoft.com/dotnet/sdk
-#      steps:
-#        - name: Checkout Dev Branch
-#          uses: actions/checkout@v3
-#          with:
-#            ref: dev
-#        - name: Setup .NET Core SDK 6
-#          uses: actions/setup-dotnet@v2
-#          with:
-#            dotnet-version: '6.0.x'
-#            include-prerelease: false
-#        - name: Install dependencies
-#          run: dotnet restore
-#          working-directory: ${{ env.DOTNET_SRC_DIR }}
-#        - name: Install tools
-#          run: dotnet tool restore 
-#        - name: Build
-#          run: dotnet build --configuration Release --no-restore
-#          working-directory: ${{ env.DOTNET_SRC_DIR }}
-#        - name: Generate Open API
-#          run: dotnet tool run swagger tofile --output ./api/v1/swagger.yaml --yaml ${{ env.DLL_FILE_PATH }} v1  
-#        - uses: actions/download-artifact@v3
-#          with:
-#            name: pr-swagger.yaml
-#            path: ./src/CarbonAware.WebApi/src/api/v1/pr-swagger.yaml
-#        - name: API Diff Comparison
-#          run: |
-#            diff ./api/v1/pr-swagger.yaml ./api/v1/swagger.yaml && echo "No API Changes detected" || echo "::warning:: API Changed"
+  api-comparison:
+      needs: container-dotnet-build
+      runs-on: ubuntu-latest
+      defaults:
+        run:
+          working-directory: ./src/CarbonAware.WebApi/src
+      container:
+        image: mcr.microsoft.com/dotnet/sdk
+      steps:
+        - name: Checkout Dev Branch
+          uses: actions/checkout@v3
+          with:
+            ref: dev
+        - name: Setup .NET Core SDK 6
+          uses: actions/setup-dotnet@v2
+          with:
+            dotnet-version: '6.0.x'
+            include-prerelease: false
+        - name: Install dependencies
+          run: dotnet restore
+          working-directory: ${{ env.DOTNET_SRC_DIR }}
+        - name: Install tools
+          run: dotnet tool restore 
+        - name: Build
+          run: dotnet build --configuration Release --no-restore
+          working-directory: ${{ env.DOTNET_SRC_DIR }}
+        - name: Generate Open API
+          run: dotnet tool run swagger tofile --output ./api/v1/swagger.yaml --yaml ${{ env.DLL_FILE_PATH }} v1  
+        - uses: actions/download-artifact@v3
+          with:
+            name: pr-swagger.yaml
+            path: ./src/CarbonAware.WebApi/src/api/v1/pr-swagger.yaml
+        - name: API Diff Comparison
+          run: |
+            diff ./api/v1/pr-swagger.yaml ./api/v1/swagger.yaml && echo "No API Changes detected" || echo "::warning:: API Changed"


### PR DESCRIPTION
This reverts commit 7c67ef125cc2efc584d967766af979552cc96df6.

## Summary
This is to revert in place the api comparison in the dev branch for merge.  Due to folder structure changes this would fail on merge (by design) but stopped the first merge of this code.

Note - when merging to main this merge step will need to take place also thef irs ttime.

## Changes

- API merge comparison put back in place

## Checklist

- [x] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?
- [] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [x] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?
None.

## Is this a breaking change?
No.

## Anything else?
No.

