### PR TITLE
Update CarbonAwareCLI.cs

### DIFF
--- a/src/CarbonAware.CLI/src/CarbonAwareCLI.cs
+++ b/src/CarbonAware.CLI/src/CarbonAwareCLI.cs
@@ -58,7 +58,7 @@ public class CarbonAwareCLI
 
     public async Task<IEnumerable<EmissionsData>> GetEmissions()
     {
-        IEnumerable<Location> locations = _state.Locations.Select(loc => new Location(){ RegionName = loc });
+        IEnumerable<Location> locations = _state.Locations.Select(loc => new Location(){ RegionName = loc, LocationType = LocationType.CloudProvider });
         var props = new Dictionary<string, object>() {
             { CarbonAwareConstants.Locations, locations },
             { CarbonAwareConstants.Start, _state.Time },


### PR DESCRIPTION
Aligning mining parameters to what the WebApi projects defaults to so the cli currently runs like the WebApi

Issue Number: [(Link to Github Issue or Azure Dev Ops Task/Story)](https://github.com/Green-Software-Foundation/carbon-aware-sdk/issues/76)

## Summary
Updated the default locationType as CloudProvider to match the WebApi project's defaults values

## Changes

- Updated the default locationType as CloudProvider to match the WebApi project's defaults values

## Checklist

- [X] Local Tests Passing?
- [] CICD and Pipeline Tests Passing?
- [] Added any new Tests?
- [] Documentation Updates Made?
- [X] Are there any API Changes? If yes, please describe below.
- [X] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?
This change simply add default parameters to align with how the WebApi currently works. Otherwise it currently errors and is unusable as is.

## Anything else?
There was another PR also describing pre-requisites to set your watttime account which will remain separate (other PR can therefore be documentation only)

```dotnet test``` output below
```
Starting test execution, please wait...
A total of 1 test files matched the specified pattern.
  Skipped ParseCommandLineArguments_ThrowsErrorWhenLocationNotProvided [< 1 ms]

Passed!  - Failed:     0, Passed:     4, Skipped:     1, Total:     5, Duration: 180 ms - /Users/dan.benitah/projects/ava/gsf/carbon-aware-sdk/src/CarbonAware.CLI/test/bin/Debug/net6.0/CarbonAware.CLI.Tests.dll (net6.0)
```
