### PR TITLE
Incorrect paths for CLI is specified in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ COPY ./entrypoint.sh ./
 
 #WORKDIR /src/
 
-RUN dotnet publish  ./CarbonAware.CLI/CarbonAware.CLI.csproj -c Release -o out --no-self-contained
-RUN cp ./CarbonAware.CLI/carbon-aware.json out
+RUN dotnet publish  ./CarbonAware.CLI/src/CarbonAware.CLI.csproj -c Release -o out --no-self-contained
+RUN cp ./CarbonAware.CLI/src/carbon-aware.json out
 RUN cp -r  ./data/data-files/ out
 
 RUN cp ./entrypoint.sh out


### PR DESCRIPTION
## Summary

I saw 2 errors when I attempted to build Docker container.  
Source files for CLI are located at `CarbonAware.CLI/src/`, however `src` does not specified in Dockerfile.

```
[1/2] STEP 4/13: RUN dotnet publish  ./CarbonAware.CLI/CarbonAware.CLI.csproj -c Release -o out --no-self-contained
MSBuild version 17.3.0+92e077650 for .NET
MSBUILD : error MSB1009: Project file does not exist.
```

```
[1/2] STEP 5/13: RUN cp ./CarbonAware.CLI/carbon-aware.json out
cp: cannot stat './CarbonAware.CLI/carbon-aware.json': No such file or directory
```

## Changes

Added `src` to paths in some commands in Dockerfile.

## Checklist

- [ ] Local Tests Passing?
- [ ] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [ ] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?

No

## Is this a breaking change?

No