### PR TITLE
Fix: CLI returns a JSON with an array inside, instead of an array

### DIFF
--- a/src/CarbonAware.CLI/src/CarbonAwareCLI.cs
+++ b/src/CarbonAware.CLI/src/CarbonAwareCLI.cs
@@ -77,9 +77,13 @@ public class CarbonAwareCLI
 
     public void OutputEmissionsData(IEnumerable<EmissionsData> emissions)
     {
-        var outputData = $"{JsonConvert.SerializeObject(emissions, Formatting.Indented)}";
-        _logger.LogCritical(outputData);
-        Console.WriteLine(outputData);
+        var emissionsData = new Dictionary<string, IEnumerable<EmissionsData>>() {
+            { "emissionsData", emissions }
+        };
+
+        var outputJson = JsonConvert.SerializeObject(emissionsData, Formatting.Indented);
+        _logger.LogCritical(outputJson);
+        Console.WriteLine(outputJson);
     }
 
     private void ValidateCommandLineArguments(CLIOptions o)

--- a/src/CarbonAware.CLI/test/CarbonAwareCLITests.cs
+++ b/src/CarbonAware.CLI/test/CarbonAwareCLITests.cs
@@ -4,6 +4,11 @@ using System;
 using System.IO;
 using CarbonAware.Aggregators.CarbonAware;
 using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
+using System.Collections;
+using CarbonAware.Model;
+using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace CarbonAware.CLI.Tests;
 
@@ -28,6 +33,34 @@ public class CarbonAwareCLITests
         
         Assert.AreEqual("test", cli._state.Locations[0]); 
         Assert.AreEqual(DateTime.Parse("2021-11-11"), cli._state.Time); 
+    }
+
+    [Test]
+    public void ParseCommandLineArguments_ReturnsJsonWithArrayInside()
+    {
+        string[] args = new string[] { "-l", "test", "-t", "2021-11-11", "--lowest" };
+
+        EmissionsData exampleEmissionsData = new EmissionsData()
+        {
+            Time = DateTime.Now + TimeSpan.FromHours(-1),
+            Location = "US",
+            Rating = 100
+        };
+
+        var cli = new CarbonAwareCLI(args, It.IsAny<ICarbonAwareAggregator>(), Mock.Of<ILogger<CarbonAwareCLI>>());
+
+        using (StringWriter writer = new StringWriter())
+        {
+            // Redirect Console.Out so we can verify what is written
+            Console.SetOut(writer);
+
+            cli.OutputEmissionsData(new List<EmissionsData> { exampleEmissionsData, exampleEmissionsData });
+
+            // Verify that output is in a JSON format. For now, just checking the first character
+            // TODO: Expand out to full verification (other tests + helper methods)
+            string jsonOutput = writer.ToString();
+            Assert.IsTrue(jsonOutput.StartsWith("{"));
+        }
     }
 
     [Test]

--- a/src/CarbonAware.CLI/test/CarbonAwareCLITests.cs
+++ b/src/CarbonAware.CLI/test/CarbonAwareCLITests.cs
@@ -4,11 +4,8 @@ using System;
 using System.IO;
 using CarbonAware.Aggregators.CarbonAware;
 using Microsoft.Extensions.Logging;
-using System.Threading.Tasks;
-using System.Collections;
 using CarbonAware.Model;
 using System.Collections.Generic;
-using Newtonsoft.Json;
 
 namespace CarbonAware.CLI.Tests;
 


### PR DESCRIPTION
Issue Number: #36 

## Summary
Looking to fix the issue where the CLI returns an array instead of a JSON. Small fix, but first time contributing!

## Changes
- Modify OutputEmissionsData#CarbonAwareCLI.cs to correct output
- Add a new test for doing a small verification of this logic (will likely want to expand out to proper tests + helpers etc in the future, but for now, wanting to kick off the review process!)

## Checklist

- [x] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?
- [x] Added any new Tests?
- [x] Are there any API Changes? If yes, please describe below.

## Are there API Changes?
If yes, what are the expected API Changes? Please link to an API-Comparison workflow with the API Diff.

Yes - we're changing the format of how the CLI returns. I believe we're moving towards a more standardized JSON approach however.

## Is this a breaking change?
If yes, what workflow does this break? 
Potentially breaking if workflows relied on just an array instead of JSON with array inside.

## Anything else?
Other comments, collaborators, etc.
This PR Closes Issue #36 
