### PR TITLE
CLI: Fix `--lowest` parameter.

### DIFF
--- a/src/CarbonAware.CLI/src/CarbonAwareCLI.cs
+++ b/src/CarbonAware.CLI/src/CarbonAwareCLI.cs
@@ -63,16 +63,22 @@ public class CarbonAwareCLI
             { CarbonAwareConstants.MultipleLocations, locations },
             { CarbonAwareConstants.Start, _state.Time },
             { CarbonAwareConstants.End, _state.ToTime },
-            { CarbonAwareConstants.Best, true }
+            { CarbonAwareConstants.Best, _state.Lowest }
         };
         return await GetEmissionsDataAsync(props);
     }
 
     private async Task<IEnumerable<EmissionsData>> GetEmissionsDataAsync(Dictionary<string, object> props)
     {
-        IEnumerable<EmissionsData> e = await _aggregator.GetEmissionsDataAsync(props);
+        if ((bool)props[CarbonAwareConstants.Best])
+        {
+            return new EmissionsData[] {await _aggregator.GetBestEmissionsDataAsync(props)};
+        }
+        else
+        {
+            return await _aggregator.GetEmissionsDataAsync(props);
+        }
 
-        return await _aggregator.GetEmissionsDataAsync(props);
     }
 
     public void OutputEmissionsData(IEnumerable<EmissionsData> emissions)


### PR DESCRIPTION
Return as an IEnumerable of a single EmissionsData element.

Signed-off-by: Szymon Duchniewicz <szymon.duchniewicz@avanade.com>

Issue Number: (Link to Github Issue or Azure Dev Ops Task/Story)

## Summary
Fix for CLI of the SDK parameter `--lowest`. Previously was omitted, now changes parameters of the request and uses `GetBestEmissionsDataAsync`. It currently doesn't check the parameter (but parses it) and only call `GetEmissionsDataAsync` of its aggregator (tested on WattTime aggregator).

## Changes

- Modify CarbonAware.CLI/src/CarbonAwareCLI.cs:
- use parsed value for `--lowest` parameter and pass it on
- Change GetEmissionsDataAsync to use `GetBestEmissionsDataAsync` and instantiate a single element array when returning the value.

## Checklist

- [x] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [ ] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?
If yes, what are the expected API Changes? Please link to an API-Comparison workflow with the API Diff.
@vaughanknight where can I find this (I assume none, but curious)

## Is this a breaking change?
No, passes all workflows (which is worrying, no tests for --lowest parameter CLI!)


## Anything else?

This PR Closes Issue #97 
