### PR TITLE
Feature/id78 watttime requests for account creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ src/CarbonAware.WebApi/src/CarbonAware.WebApi.xml
 !.vscode/launch.json
 !.vscode/tasks.json
 .DS_Store
+
+samples/watttime-registration/settings.py

--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -15,7 +15,7 @@ Each of these has configuration requirements which are detailed below.
 Make sure you have installed the following pre-requisites:
 
 - dotnet core SDK [https://dotnet.microsoft.com/en-us/download](https://dotnet.microsoft.com/en-us/download)
-- WattTime account - See [instruction on WattTime](https://www.watttime.org/api-documentation/#register-new-user) for details.
+- WattTime account - See [instruction on WattTime](https://www.watttime.org/api-documentation/#register-new-user) for details (or use our python samples as described [here](samples/watttime-registration/readme.md)).
 
 ## Data Sources
 

--- a/samples/watttime-registration/1-register.py
+++ b/samples/watttime-registration/1-register.py
@@ -1,0 +1,10 @@
+import requests
+from settings import *
+
+register_url = 'https://api2.watttime.org/v2/register'
+params = {'username': wt_username,
+         'password': wt_password,
+         'email': wt_email,
+         'org': wt_org}
+rsp = requests.post(register_url, json=params)
+print(rsp.text)

--- a/samples/watttime-registration/2-requesttoken.py
+++ b/samples/watttime-registration/2-requesttoken.py
@@ -1,0 +1,7 @@
+import requests
+from requests.auth import HTTPBasicAuth
+from settings import *
+
+login_url = 'https://api2.watttime.org/v2/login'
+rsp = requests.get(login_url, auth=HTTPBasicAuth(wt_username, wt_password))
+print(rsp.json())

--- a/samples/watttime-registration/3-makerequest.py
+++ b/samples/watttime-registration/3-makerequest.py
@@ -1,0 +1,14 @@
+import requests
+from requests.auth import HTTPBasicAuth
+from settings import *
+
+login_url = 'https://api2.watttime.org/v2/login'
+token = requests.get(login_url, auth=HTTPBasicAuth(wt_username, wt_password)).json()['token']
+
+data_url = 'https://api2.watttime.org/v2/data'
+headers = {'Authorization': 'Bearer {}'.format(token)}
+params = {'ba': 'CAISO_NORTH', 
+          'starttime': '2019-02-20T16:00:00-0800', 
+          'endtime': '2019-02-20T16:15:00-0800'}
+rsp = requests.get(data_url, headers=headers, params=params)
+print(rsp.text)

--- a/samples/watttime-registration/readme.md
+++ b/samples/watttime-registration/readme.md
@@ -1,0 +1,68 @@
+# Watttime account creation 
+
+In order to create an account for watttime, we have set up these sample requests to help you get set up very quickly.
+
+> Note these steps reflect the documentation at  https://www.watttime.org/api-documentation/#best-practices-for-api-usage
+
+> This sample is in python
+
+Please follow these steps to get started quickly:
+
+## 1 - Update settings
+
+Copy the template settings file to a new `settings.py` file and edit the parameters.
+
+### 1.1 Copy
+
+To copy you can use:
+```sh
+cp ./settings.py.template settings.py
+```
+
+### 1.2 Update settings.py
+
+Update the file to use your desired username, password and other values needed.
+
+## 2 - Register.py
+
+```sh
+python ./1-register.py
+```
+
+Success should look like the following:
+
+```json
+{"user":"gsf_myusername","ok":"User created"}
+```
+
+## 3 - Test
+
+Your account should now have been created and you should be able to run the following tests.
+
+### 3.1 - Request token
+
+
+```sh
+python ./2-requesttoken.py
+```
+
+Success should look like the following(token was truncated in result below):
+
+```json
+{"token": "eyJhbGci...."}
+```
+
+
+### 3.2 - Make a request
+
+You could make a request for data from watttime. Run:
+
+```sh
+python ./3-makerequest.py
+```
+
+Success should look like the following:
+
+```json
+[{"point_time": "2019-02-21T00:15:00.000Z", "value": 1062.0, "frequency": null, "market": "RTM", "ba": "CAISO_NORTH", "datatype": "MOER", "version": "3.0"}, {"point_time": "2019-02-21T00:10:00.000Z", "value": 1050.0, "frequency": null, "market": "RTM", "ba": "CAISO_NORTH", "datatype": "MOER", "version": "3.0"}, {"point_time": "2019-02-21T00:05:00.000Z", "value": 1019.0, "frequency": null, "market": "RTM", "ba": "CAISO_NORTH", "datatype": "MOER", "version": "3.0"}, {"point_time": "2019-02-21T00:00:00.000Z", "value": 927.0, "frequency": null, "market": "RTM", "ba": "CAISO_NORTH", "datatype": "MOER", "version": "3.0"}]
+```

--- a/samples/watttime-registration/settings.py.template
+++ b/samples/watttime-registration/settings.py.template
@@ -1,0 +1,4 @@
+wt_username = "gsf_<set your username here>"
+wt_password = "your password here"
+wt_email = "myemail @ email provide .com" # your email
+wt_org = "CarbonAwareSDK" #your organisation


### PR DESCRIPTION
Issue Number: #78 

## Summary
This PR adds some sample python code to help quickly create a watttime account

## Changes

- Sample added to samples root folder
- instructions on how to run these samples

## Checklist

- [X] Documentation Updates Made?
- [X] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?
No

## Is this a breaking change?
No

## Anything else?
Other comments, collaborators, etc.
This PR contributes towards issue #78 