### PR TITLE
Refactor integration test mocks into new projects

### DIFF
--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/mock/CarbonAware.DataSources.Json.Mocks.csproj
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/mock/CarbonAware.DataSources.Json.Mocks.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\CarbonAware.DataSources.Mocks\mock\CarbonAware.DataSources.Mocks.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/mock/JsonDataSourceMocker.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/mock/JsonDataSourceMocker.cs
@@ -1,16 +1,11 @@
-﻿using Microsoft.AspNetCore.Mvc.Testing;
+﻿using CarbonAware.DataSources.Mocks;
 
-namespace CarbonAware.WebApi.IntegrationTests;
+namespace CarbonAware.DataSources.Json.Mocks;
 public class JsonDataSourceMocker : IDataSourceMocker
 {
-    internal JsonDataSourceMocker() { }
+    public JsonDataSourceMocker() { }
 
     public void SetupDataMock(DateTimeOffset start, DateTimeOffset end, string location) { }
-
-    public WebApplicationFactory<Program> OverrideWebAppFactory(WebApplicationFactory<Program> factory)
-    {
-        return factory;
-    }
     public void SetupForecastMock() { }
     public void Initialize() { }
     public void Reset() { }

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Mocks/mock/CarbonAware.DataSources.Mocks.csproj
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Mocks/mock/CarbonAware.DataSources.Mocks.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Mocks/mock/IDataSourceMocker.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Mocks/mock/IDataSourceMocker.cs
@@ -1,11 +1,4 @@
-﻿using Microsoft.AspNetCore.Mvc.Testing;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace CarbonAware.WebApi.IntegrationTests;
+namespace CarbonAware.DataSources.Mocks;
 
 /// <summary>
 /// This interface is used by the Integration Tests to set up data for different data sources
@@ -13,14 +6,6 @@ namespace CarbonAware.WebApi.IntegrationTests;
 /// </summary>
 public interface IDataSourceMocker
 {
-    /// <summary>
-    /// This method overrides configuration, service and builder settings in a web app factory
-    /// Used to add singletons or change config settings as needed for the datasource
-    /// </summary>
-    /// <param name="factory">The WebAppFactory passed in that will be overriden/changed</param>
-    /// <returns></returns>
-    public WebApplicationFactory<Program> OverrideWebAppFactory(WebApplicationFactory<Program> factory);
-
     /// <summary>
     /// This sets up a data endpoint with certain parameters so that it can be pinged.
     /// </summary>

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/mock/CarbonAware.DataSources.WattTime.Mocks.csproj
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/mock/CarbonAware.DataSources.WattTime.Mocks.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="WireMock.Net" Version="1.4.43" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\CarbonAware.DataSources.Mocks\mock\CarbonAware.DataSources.Mocks.csproj" />
+    <ProjectReference Include="..\..\..\CarbonAware.Tools\CarbonAware.Tools.WattTimeClient\src\CarbonAware.Tools.WattTimeClient.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/mock/WattTimeDataSourceMocker.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/mock/WattTimeDataSourceMocker.cs
@@ -1,21 +1,17 @@
-﻿using CarbonAware.DataSources.Configuration;
-using CarbonAware.Tools.WattTimeClient.Configuration;
+﻿using CarbonAware.DataSources.Mocks;
 using CarbonAware.Tools.WattTimeClient.Constants;
 using CarbonAware.Tools.WattTimeClient.Model;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.Extensions.DependencyInjection;
 using System.Net;
 using System.Net.Mime;
 using System.Text.Json;
-using WireMock.Server;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
+using WireMock.Server;
 
-namespace CarbonAware.WebApi.IntegrationTests;
+namespace CarbonAware.DataSources.WattTime.Mocks;
 public class WattTimeDataSourceMocker : IDataSourceMocker
 {
     protected WireMockServer _server;
-    private readonly object _dataSource = DataSourceType.WattTime;
 
     private static readonly BalancingAuthority defaultBalancingAuthority = new()
     {
@@ -26,9 +22,10 @@ public class WattTimeDataSourceMocker : IDataSourceMocker
 
     private static readonly LoginResult defaultLoginResult = new() { Token = "myDefaultToken123" };
 
-    internal WattTimeDataSourceMocker()
+    public WattTimeDataSourceMocker()
     {
         _server = WireMockServer.Start();
+        Environment.SetEnvironmentVariable("WattTimeClient__BaseURL", _server.Url!);
         Initialize();
     }
 
@@ -130,20 +127,6 @@ public class WattTimeDataSourceMocker : IDataSourceMocker
             }
         };
         SetupResponseGivenGetRequest(Paths.Forecast, JsonSerializer.Serialize(forecastData));
-    }
-
-    public WebApplicationFactory<Program> OverrideWebAppFactory(WebApplicationFactory<Program> factory)
-    {
-        return factory.WithWebHostBuilder(builder =>
-        {
-            builder.ConfigureServices(services =>
-            {
-                services.Configure<WattTimeClientConfiguration>(configOpt =>
-                {
-                    configOpt.BaseUrl = _server.Url!;
-                });
-            });
-        });
     }
 
     public void Initialize()

--- a/src/CarbonAware.Tools/CarbonAware.Tools.WattTimeClient/src/InternalsVisibleTo.cs
+++ b/src/CarbonAware.Tools/CarbonAware.Tools.WattTimeClient/src/InternalsVisibleTo.cs
@@ -1,4 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly:InternalsVisibleTo("CarbonAware.Tools.WattTimeClient.Tests")]
-[assembly:InternalsVisibleTo("CarbonAware.WebApi.IntegrationTests")]
+[assembly:InternalsVisibleTo("CarbonAware.DataSources.WattTime.Mocks")]

--- a/src/CarbonAware.WebApi/test/integrationTests/CarbonAware.WebApi.IntegrationTests.csproj
+++ b/src/CarbonAware.WebApi/test/integrationTests/CarbonAware.WebApi.IntegrationTests.csproj
@@ -24,7 +24,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\CarbonAware.Tools\CarbonAware.Tools.WattTimeClient\src\CarbonAware.Tools.WattTimeClient.csproj" />
+    <ProjectReference Include="..\..\..\CarbonAware.DataSources\CarbonAware.DataSources.Json\mock\CarbonAware.DataSources.Json.Mocks.csproj" />
+    <ProjectReference Include="..\..\..\CarbonAware.DataSources\CarbonAware.DataSources.WattTime\mock\CarbonAware.DataSources.WattTime.Mocks.csproj" />
     <ProjectReference Include="..\..\src\CarbonAware.WebApi.csproj" />
   </ItemGroup>
 

--- a/src/CarbonAware.WebApi/test/integrationTests/CarbonAwareControllerTests.cs
+++ b/src/CarbonAware.WebApi/test/integrationTests/CarbonAwareControllerTests.cs
@@ -1,9 +1,9 @@
 using CarbonAware.DataSources.Configuration;
 using CarbonAware.WebApi.IntegrationTests;
+using CarbonAware.WebApi.Models;
 using NUnit.Framework;
 using System.Net;
 using System.Text.Json;
-using CarbonAware.WebApi.Models;
 
 namespace CarbonAware.WepApi.IntegrationTests;
 
@@ -58,7 +58,7 @@ public class CarbonAwareControllerTests : IntegrationTestingBase
         queryStrings["time"] = $"{start:O}";
         queryStrings["toTime"] = $"{end:O}";
 
-        var endpointURI = ConstructUriWithQueryString(bestLocationsURI,queryStrings);
+        var endpointURI = ConstructUriWithQueryString(bestLocationsURI, queryStrings);
 
         //Get response and response content
         var result = await _client.GetAsync(endpointURI);
@@ -166,7 +166,8 @@ public class CarbonAwareControllerTests : IntegrationTestingBase
         IgnoreTestForDataSource("data source does not implement '/emissions/forecasts/batch'", DataSourceType.JSON);
 
         _dataSourceMocker.SetupForecastMock();
-        var forecastData = Enumerable.Range(0, 1).Select(x => new {
+        var forecastData = Enumerable.Range(0, 1).Select(x => new
+        {
             location = location,
             requestedAt = requestedAt
         });
@@ -187,7 +188,8 @@ public class CarbonAwareControllerTests : IntegrationTestingBase
         var expectedDataStartAt = DateTimeOffset.Parse(start);
         var expectedDataEndAt = DateTimeOffset.Parse(end);
         _dataSourceMocker.SetupBatchForecastMock();
-        var inputData = Enumerable.Range(0, nelems).Select(x => new {
+        var inputData = Enumerable.Range(0, nelems).Select(x => new
+        {
             requestedAt = reqAt,
             dataStartAt = start,
             dataEndAt = end,
@@ -271,7 +273,8 @@ public class CarbonAwareControllerTests : IntegrationTestingBase
     [TestCase("westus", "2022-3-1T15:30:00Z", "2022-3-1T18:00:00Z", TestName = "EmissionsMarginalCarbonIntensityBatch returns BadRequest for wrong date format")]
     public async Task EmissionsMarginalCarbonIntensityBatch_MissingRequiredParams_ReturnsBadRequest(string location, string startTime, string endTime)
     {
-        var intesityData = Enumerable.Range(0, 1).Select(x => new {
+        var intesityData = Enumerable.Range(0, 1).Select(x => new
+        {
             location = location,
             startTime = startTime,
             endTime = endTime
@@ -289,7 +292,8 @@ public class CarbonAwareControllerTests : IntegrationTestingBase
         var startDate = DateTimeOffset.Parse(start);
         var endDate = DateTimeOffset.Parse(end);
         _dataSourceMocker.SetupDataMock(startDate, endDate, location);
-        var intesityData = Enumerable.Range(0, nelems).Select(x => new {
+        var intesityData = Enumerable.Range(0, nelems).Select(x => new
+        {
             location = location,
             startTime = start,
             endTime = end

--- a/src/CarbonAware.WebApi/test/integrationTests/IntegrationTestingBase.cs
+++ b/src/CarbonAware.WebApi/test/integrationTests/IntegrationTestingBase.cs
@@ -1,4 +1,7 @@
 ﻿using CarbonAware.DataSources.Configuration;
+using CarbonAware.DataSources.Json.Mocks;
+using CarbonAware.DataSources.Mocks;
+using CarbonAware.DataSources.WattTime.Mocks;
 using Microsoft.AspNetCore.Mvc.Testing;
 using NUnit.Framework;
 using System.Net.Http.Headers;
@@ -93,9 +96,7 @@ public abstract class IntegrationTestingBase
                 }
         }
 
-        //Setup the WebAppFactory with custom settings as required by the datasource
-        //For instance, overriding specific clients with new URLs.
-        _factory = _dataSourceMocker.OverrideWebAppFactory(_factory);
+        // After initializing and configuring the data source, we can now create the client from our factory
         _client = _factory.CreateClient();
     }
 

--- a/src/CarbonAwareSDK.sln
+++ b/src/CarbonAwareSDK.sln
@@ -47,6 +47,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CarbonAware.CLI.Tests", "Ca
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CarbonAware.WebApi.IntegrationTests", "CarbonAware.WebApi\test\integrationTests\CarbonAware.WebApi.IntegrationTests.csproj", "{E8DA93FD-C439-4BCD-899A-7FD7D90951A9}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CarbonAware.DataSources.Mocks", "CarbonAware.DataSources\CarbonAware.DataSources.Mocks\mock\CarbonAware.DataSources.Mocks.csproj", "{A4928C64-8F2D-4AA9-8563-C36178CEAA1D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CarbonAware.DataSources.Json.Mocks", "CarbonAware.DataSources\CarbonAware.DataSources.Json\mock\CarbonAware.DataSources.Json.Mocks.csproj", "{BACD9DDF-2C7E-45E5-ADB8-539722A8645D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CarbonAware.DataSources.WattTime.Mocks", "CarbonAware.DataSources\CarbonAware.DataSources.WattTime\mock\CarbonAware.DataSources.WattTime.Mocks.csproj", "{69DA1C7F-740E-406D-B62F-7E84175378B2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -141,6 +147,18 @@ Global
 		{E8DA93FD-C439-4BCD-899A-7FD7D90951A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E8DA93FD-C439-4BCD-899A-7FD7D90951A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E8DA93FD-C439-4BCD-899A-7FD7D90951A9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A4928C64-8F2D-4AA9-8563-C36178CEAA1D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A4928C64-8F2D-4AA9-8563-C36178CEAA1D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A4928C64-8F2D-4AA9-8563-C36178CEAA1D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A4928C64-8F2D-4AA9-8563-C36178CEAA1D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BACD9DDF-2C7E-45E5-ADB8-539722A8645D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BACD9DDF-2C7E-45E5-ADB8-539722A8645D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BACD9DDF-2C7E-45E5-ADB8-539722A8645D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BACD9DDF-2C7E-45E5-ADB8-539722A8645D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{69DA1C7F-740E-406D-B62F-7E84175378B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{69DA1C7F-740E-406D-B62F-7E84175378B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{69DA1C7F-740E-406D-B62F-7E84175378B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{69DA1C7F-740E-406D-B62F-7E84175378B2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Issue Number: #122 

## Summary
Refactor integration test mocks into new projects

## Changes

- Move mocks into their own projects within `src/CarbonAware.DataSources/`
  - `CarbonAware.DataSources.Mocks` for the shared interface
  - `CarbonAware.DataSources.Json/mock` for the Json mocker
  - `CarbonAware.DataSources.WattTime/mock` for the WattTime mocker
- Removed `OverrideWebAppFactory` from interface/implementations in favor of more consistent approach to configuration (using env vars) that also allows the interface to live outside the test suite.
- Visual Studio did some light cleanup around using directives

## Checklist

- [x] Local Tests Passing?
- [ ] CICD and Pipeline Tests Passing?
- [x] Added any new Tests?
- [x] Documentation Updates Made?
- [x] Are there any API Changes? If yes, please describe below.
- [x] This is not a breaking change. If it is, please describe it below.

## Are there API Changes? NO

## Is this a breaking change? NO

## Anything else?
Other comments, collaborators, etc.
This PR Closes Issue #122 
