### PR TITLE
Improve Reading Content from WattTime

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -167,6 +167,12 @@ You can configure the verbosity of the application error messages by setting the
 CarbonAwareVars__VerboseApi="true"
 ```
 
+### WattTimeClient Caching BalancingAuthority
+To improve performance communicating with the WattTime API service, the client caches the data mapping location coordinates to balancing authorities.  By default, this data is stored in an in-memory cache for `86400` seconds, but expiration can be configured using the setting `BalancingAuthorityCacheTTL` (Set to "0" to not use cache).  The regional boundaries of a balancing authority tend to be stable, but as they can change, the [WattTime documentation](https://www.watttime.org/api-documentation/#determine-grid-region) recommends not caching for longer than 1 month.
+```bash
+WattTimeClient__BalancingAuthorityCacheTTL="90"
+```
+
 ### Sample Environment Variable Configuration Using WattTime
 
 ```bash

--- a/src/CarbonAware.Tools/CarbonAware.Tools.WattTimeClient/src/Configuration/ServiceCollectionExtensions.cs
+++ b/src/CarbonAware.Tools/CarbonAware.Tools.WattTimeClient/src/Configuration/ServiceCollectionExtensions.cs
@@ -46,7 +46,7 @@ public static class ServiceCollectionExtensions
         {
             services.AddHttpClient<WattTimeClient>(IWattTimeClient.NamedClient);
         }
-
+        services.AddMemoryCache();
         services.TryAddSingleton<IWattTimeClient, WattTimeClient>();
 
         return services;

--- a/src/CarbonAware.Tools/CarbonAware.Tools.WattTimeClient/src/Configuration/WattTimeClientConfiguration.cs
+++ b/src/CarbonAware.Tools/CarbonAware.Tools.WattTimeClient/src/Configuration/WattTimeClientConfiguration.cs
@@ -24,6 +24,12 @@ public class WattTimeClientConfiguration
     public string BaseUrl { get; set; } = "https://api2.watttime.org/v2/";
 
     /// <summary>
+    /// Gets or sets the cached expiration time (in seconds) for a BalancingAuthority instance.
+    /// It defaults to 86400 secs.
+    /// </summary>
+    public int BalancingAuthorityCacheTTL { get; set; } = 86400;
+
+    /// <summary>
     /// Validate that this object is properly configured.
     /// </summary>
     public void Validate()

--- a/src/CarbonAware.Tools/CarbonAware.Tools.WattTimeClient/test/WattTimeClientTests.cs
+++ b/src/CarbonAware.Tools/CarbonAware.Tools.WattTimeClient/test/WattTimeClientTests.cs
@@ -1,5 +1,6 @@
 ﻿using CarbonAware.Tools.WattTimeClient.Configuration;
 using CarbonAware.Tools.WattTimeClient.Model;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -8,7 +9,6 @@ using Moq;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -39,6 +39,8 @@ public class WattTimeClientTests
 
     private readonly string DefaultTokenValue = "myDefaultToken123";
 
+    private IMemoryCache MemoryCache { get; set; }
+
     [SetUp]
     public void Initialize()
     {
@@ -62,7 +64,7 @@ public class WattTimeClientTests
         });
 
         this.BasicAuthValue = "invalid";
-        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
+        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         
         Assert.ThrowsAsync<WattTimeClientHttpException>(async () => await client.GetDataAsync("ba", new DateTimeOffset(), new DateTimeOffset()));
         Assert.ThrowsAsync<WattTimeClientHttpException>(async () => await client.GetCurrentForecastAsync("ba"));
@@ -81,7 +83,7 @@ public class WattTimeClientTests
             return Task.FromResult(response);
         });
 
-        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
+        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
 
         Assert.ThrowsAsync<JsonException>(async () => await client.GetDataAsync("ba", new DateTimeOffset(), new DateTimeOffset()));
@@ -99,7 +101,7 @@ public class WattTimeClientTests
             return Task.FromResult(response);
         });
 
-        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
+        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
 
         var data = await client.GetDataAsync("balauth", new DateTimeOffset(2022, 4, 22, 0, 0, 0, TimeSpan.Zero), new DateTimeOffset(2022, 4, 22, 0, 0, 0, TimeSpan.Zero));
@@ -125,7 +127,7 @@ public class WattTimeClientTests
             return Task.FromResult(response);
         });
 
-        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
+        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
 
         var data = await client.GetDataAsync("balauth", new DateTimeOffset(), new DateTimeOffset());
@@ -145,7 +147,7 @@ public class WattTimeClientTests
             return Task.FromResult(response);
         });
 
-        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
+        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
 
         var data = await client.GetDataAsync("balauth", new DateTimeOffset(), new DateTimeOffset());
 
@@ -164,7 +166,7 @@ public class WattTimeClientTests
         });
 
 
-        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
+        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
         var ba = new BalancingAuthority(){ Abbreviation = "balauth" };
 
@@ -181,7 +183,7 @@ public class WattTimeClientTests
             return Task.FromResult(response);
         });
 
-        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
+        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
         var ba = new BalancingAuthority(){ Abbreviation = "balauth" };
 
@@ -200,7 +202,7 @@ public class WattTimeClientTests
             return Task.FromResult(response);
         });
 
-        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
+        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
 
         var ba = new BalancingAuthority(){ Abbreviation = "balauth" };
@@ -230,7 +232,7 @@ public class WattTimeClientTests
             return Task.FromResult(response);
         });
 
-        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
+        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
 
         var forecast = await client.GetCurrentForecastAsync("balauth");
@@ -251,7 +253,7 @@ public class WattTimeClientTests
             return Task.FromResult(response);
         });
 
-        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
+        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
 
         this.HttpClient.DefaultRequestHeaders.Authorization = null;
 
@@ -272,7 +274,7 @@ public class WattTimeClientTests
             return Task.FromResult(response);
         });
 
-        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
+        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
         var ba = new BalancingAuthority(){ Abbreviation = "balauth" };
 
@@ -289,7 +291,7 @@ public class WattTimeClientTests
             return Task.FromResult(response);
         });
 
-        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
+        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
         var ba = new BalancingAuthority(){ Abbreviation = "balauth" };
 
@@ -308,7 +310,7 @@ public class WattTimeClientTests
             return Task.FromResult(response);
         });
 
-        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
+        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
         var ba = new BalancingAuthority(){ Abbreviation = "balauth" };
 
@@ -336,7 +338,7 @@ public class WattTimeClientTests
             return Task.FromResult(response);
         });
 
-        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
+        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
 
         var forecast = await client.GetForecastOnDateAsync("balauth", new DateTimeOffset());
@@ -353,7 +355,7 @@ public class WattTimeClientTests
             return Task.FromResult(response);
         });
 
-        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
+        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
 
         this.HttpClient.DefaultRequestHeaders.Authorization = null;
 
@@ -371,7 +373,7 @@ public class WattTimeClientTests
             return Task.FromResult(response);
         });
 
-        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
+        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
 
         Assert.ThrowsAsync<JsonException>(async () => await client.GetBalancingAuthorityAsync("lat", "long"));
@@ -386,7 +388,7 @@ public class WattTimeClientTests
             return Task.FromResult(response);
         });
 
-        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
+        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
 
         Assert.ThrowsAsync<WattTimeClientException>(async () => await client.GetBalancingAuthorityAsync("lat", "long"));
@@ -403,7 +405,7 @@ public class WattTimeClientTests
             return Task.FromResult(response);
         });
 
-        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
+        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
 
         var ba = await client.GetBalancingAuthorityAsync("lat", "long");
@@ -424,7 +426,7 @@ public class WattTimeClientTests
             return Task.FromResult(response);
         });
 
-        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
+        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
 
         var ba = await client.GetBalancingAuthorityAsync("lat", "long");
@@ -443,7 +445,7 @@ public class WattTimeClientTests
             return Task.FromResult(response);
         });
 
-        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
+        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
 
         this.HttpClient.DefaultRequestHeaders.Authorization = null;
 
@@ -464,7 +466,7 @@ public class WattTimeClientTests
                 return Task.FromResult(response);
             });
 
-            var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
+            var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
             client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
 
             var result = await client.GetHistoricalDataAsync("ba");
@@ -487,7 +489,7 @@ public class WattTimeClientTests
             });
 
             this.HttpClient.DefaultRequestHeaders.Authorization = null;
-            var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
+            var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
 
             var result = await client.GetHistoricalDataAsync("ba");
             var sr = new StreamReader(result);
@@ -508,7 +510,7 @@ public class WattTimeClientTests
                 return Task.FromResult(response);
             });
 
-            var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
+            var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
             client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
 
             var result = await client.GetHistoricalDataAsync("ba");
@@ -533,6 +535,7 @@ public class WattTimeClientTests
             .Build();
         var serviceCollection = new ServiceCollection();
         serviceCollection.ConfigureWattTimeClient(configuration);
+        serviceCollection.AddMemoryCache();
         var serviceProvider = serviceCollection.BuildServiceProvider();
         var client = serviceProvider.GetRequiredService<IWattTimeClient>();
         Assert.ThrowsAsync<HttpRequestException>(async () => await client.GetBalancingAuthorityAsync("lat", "long"));
@@ -559,6 +562,7 @@ public class WattTimeClientTests
         this.HttpClientFactory = Mock.Of<IHttpClientFactory>();
         Mock.Get(this.HttpClientFactory).Setup(h => h.CreateClient(IWattTimeClient.NamedClient)).Returns(this.HttpClient);
         this.HttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", this.DefaultTokenValue);
+        this.MemoryCache = new MemoryCache(new MemoryCacheOptions());
     }
 
     private HttpResponseMessage MockWattTimeAuthResponse(HttpRequestMessage request, HttpContent reponseContent, string? validToken = null)


### PR DESCRIPTION
Issue Number: #124 

## Summary
- Fetch data from WattTime service using streams instead of strings
- Cache in-memory a BalanceAuthority instance to avoid hitting WattTime service all the time for the same item.

## Changes
- Improve retrieving the data when the header is available, then client can start to stream it, instead of waiting until all the content (string) is in available in memory.
- Change how WattTime Client reads content from the BA requests by leveraging the cache.

## Checklist

- [x] Local Tests Passing?
- [ ] CICD and Pipeline Tests Passing?
- [x] Added any new Tests?
- [x] Documentation Updates Made?
- [x] Are there any API Changes? If yes, please describe below.
- [x] This is not a breaking change. If it is, please describe it below.

## Are there API Changes? NO

## Is this a breaking change? NO

## Anything else?
Other comments, collaborators, etc.
This PR Closes Issue #124 
