### PR TITLE
Bug/appsettings local fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,5 @@ src/CarbonAware.WebApi/src/CarbonAware.WebApi.xml
 
 samples/watttime-registration/settings.py
 
-# exclude local settings to easily set up your repo from the appsettings.local.json.temlpate
-appsettings.local.json
+# exclude local settings to easily set up your repo from the appsettings.Development.json.template
+appsettings.Development.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
       "preLaunchTask": "build",
       "program": "${workspaceFolder}/src/CarbonAware.WebApi/src/bin/Debug/net6.0/CarbonAware.WebApi.dll",
       "args": [],
-      "cwd": "${workspaceFolder}/src/CarbonAware.WebApi/",
+      "cwd": "${workspaceFolder}/src/CarbonAware.WebApi/src/",
       "stopAtEntry": false,
       "serverReadyAction": {
         "action": "openExternally",

--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -46,10 +46,11 @@ Note that double underscores are used to represent dotted notation or child elem
 
 #### Local project settings
 
-You have the possibility to use an untracked local settings file to override the project settings (that is loaded after the environement variables and will therefore superseed any variables of the same name).
+For local-only settings you can use environment variables, [the Secret Manager tool](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-6.0&tabs=windows#secret-manager), or an untracked Development appsettings file to override the default project settings.
 
-Todo so, rename a copy of the local template called `appsettings.local.json.template` to `appsettings.local.json`.
-Remove the first line of (invalid comments) and update the variables accordingly.
+To use the settings file, rename a copy of the template called `appsettings.Development.json.template` to `appsettings.Development.json` and remove the first line of (invalid) comments. Then update any settings according to your preferences.
+
+> Wherever possible, the projects leverage the [default .NET configuration](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-6.0#default-application-configuration-sources) expectations.  Thus, they can be configured using any file matching the format: `appsettings.<ENV>.json`. Where `<ENV>` is the value of the `ASPNETCORE_ENVIRONMENT` environment variable. By convention projects tend to use the provided HostEnvironment constants `Development`, `Staging`, and `Production`. 
 
 ### CarbonAwareSDK Specific Configuration
 

--- a/src/CarbonAware.CLI/src/CarbonAware.CLI.csproj
+++ b/src/CarbonAware.CLI/src/CarbonAware.CLI.csproj
@@ -21,6 +21,9 @@
     <Content Include="carbon-aware.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="appsettings.*">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>
@@ -36,14 +39,6 @@
     <ProjectReference Include="..\..\CarbonAware.Aggregators\src\CarbonAware.Aggregators.csproj" />
 </ItemGroup>
 
- <ItemGroup>
-    <None Update="appsettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-   <None Update="appsettings.local.json">
-    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-   </None>
-  </ItemGroup>
 
  <Target Name="CopyDataFiles" AfterTargets="Build">
 		<ItemGroup>

--- a/src/CarbonAware.CLI/src/CarbonAware.CLI.csproj
+++ b/src/CarbonAware.CLI/src/CarbonAware.CLI.csproj
@@ -40,6 +40,9 @@
     <None Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+   <None Update="appsettings.local.json">
+    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+   </None>
   </ItemGroup>
 
  <Target Name="CopyDataFiles" AfterTargets="Build">

--- a/src/CarbonAware.CLI/src/Properties/launchSettings.json
+++ b/src/CarbonAware.CLI/src/Properties/launchSettings.json
@@ -2,7 +2,10 @@
   "profiles": {
     "CarbonAwareCLI": {
       "commandName": "Project",
-      "commandLineArgs": "-l eastus westus australiaeast northeurope -t 2021-12-28 --toTime 2021-12-30 -v --lowest "
+      "commandLineArgs": "-l eastus westus australiaeast northeurope -t 2021-12-28 --toTime 2021-12-30 -v --lowest ",
+      "environmentVariables": {
+            "ASPNETCORE_ENVIRONMENT": "Development"
+      }
     }
   }
 }

--- a/src/CarbonAware.CLI/src/appsettings.Development.json.template
+++ b/src/CarbonAware.CLI/src/appsettings.Development.json.template
@@ -1,4 +1,4 @@
-//copy this file as "appsettings.local.json",  remove this comment and update the settings below accordingly
+//copy this file as "appsettings.Development.json",  remove this comment and update the settings below accordingly
 {
   "carbonAwareVars": {
     "carbonIntensityDataSource": "WattTime",

--- a/src/CarbonAware.WebApi/src/Program.cs
+++ b/src/CarbonAware.WebApi/src/Program.cs
@@ -7,16 +7,12 @@ using CarbonAware.WebApi.Configuration;
 using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
-
-
-var configurationBuilder = new ConfigurationBuilder()
-                .AddJsonFile("appsettings.json")
-                .AddEnvironmentVariables()
-                .AddJsonFile("appsettings.local.json", optional:true);// Optional and would locally set variables override environment variables
-        var config2 = configurationBuilder.Build();
+// Add order of precedence for configuration.
+builder.Configuration.AddJsonFile("appsettings.json")
+                            .AddEnvironmentVariables()
+                            .AddJsonFile("appsettings.local.json", optional:true);
 
 // Add services to the container.
-
 builder.Services.AddControllers(options =>
 {
     options.Filters.Add<HttpResponseExceptionFilter>();
@@ -33,7 +29,6 @@ builder.Services.AddSwaggerGen(c =>
        });
 });
 
-builder.Services.Configure<CarbonAwareVariablesConfiguration>(config2.GetSection(CarbonAwareVariablesConfiguration.Key));
 builder.Services.AddCarbonAwareEmissionServices(builder.Configuration);
 CarbonAwareVariablesConfiguration config = new CarbonAwareVariablesConfiguration();
 

--- a/src/CarbonAware.WebApi/src/Program.cs
+++ b/src/CarbonAware.WebApi/src/Program.cs
@@ -7,10 +7,6 @@ using CarbonAware.WebApi.Configuration;
 using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
-// Add order of precedence for configuration.
-builder.Configuration.AddJsonFile("appsettings.json")
-                            .AddEnvironmentVariables()
-                            .AddJsonFile("appsettings.local.json", optional:true);
 
 // Add services to the container.
 builder.Services.AddControllers(options =>
@@ -28,6 +24,8 @@ builder.Services.AddSwaggerGen(c =>
            return apiDesc.TryGetMethodInfo(out MethodInfo methodInfo) ? methodInfo.Name : null;
        });
 });
+
+builder.Services.Configure<CarbonAwareVariablesConfiguration>(builder.Configuration.GetSection(CarbonAwareVariablesConfiguration.Key));
 
 builder.Services.AddCarbonAwareEmissionServices(builder.Configuration);
 CarbonAwareVariablesConfiguration config = new CarbonAwareVariablesConfiguration();

--- a/src/CarbonAware.WebApi/src/appsettings.Development.json
+++ b/src/CarbonAware.WebApi/src/appsettings.Development.json
@@ -1,8 +1,0 @@
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  }
-}

--- a/src/CarbonAware.WebApi/src/appsettings.Development.json.template
+++ b/src/CarbonAware.WebApi/src/appsettings.Development.json.template
@@ -1,4 +1,4 @@
-//copy this file as "appsettings.local.json",  remove this comment and update the settings below accordingly
+//copy this file as "appsettings.Development.json",  remove this comment and update the settings below accordingly
 {
   "carbonAwareVars": {
     "carbonIntensityDataSource": "WattTime",


### PR DESCRIPTION
Issue Number: #134 
## Summary
Fixes a bug where `appsetting.local.json` where not being read both in the CLI and Web API, in a development environment. Instead implements .NET default configuration as suggested and added by @bderusha (taken from documentation): 

> Thus, they can be configured using any file matching the format: `appsettings.<ENV>.json`. Where `<ENV>` is the value of the `ASPNETCORE_ENVIRONMENT` environment variable. By convention projects tend to use the provided HostEnvironment constants `Development`, `Staging`, and `Production`. 


## Changes

- .vscode/launch.json: Change Working directory (`cwd`) to point to `CarbonAware.WebApi/src`
- GettingStarted docs updated with configuration details.
- CLI:
  - Change the `appsettings.json` file in `.csproj` to a wildcard value instead: `appsettings.*`
  - `Program.cs`: Take into consideration `ASPNETCORE_ENVIRONMENT` variable for configuration and add corresponding files to config.
  - Set `ASPNETCORE_ENVIRONMENT` to `Development` by default in `Properties/launchSettings.json`.
  - Rename `appsettings.local.json.template` to `appsettings.Development.json.template`

- Web API:
  - Remove `ConfigurationBuilder`
  - Rename `appsettings.local.json.template` to `appsettings.Development.json.template`


## Checklist

- [x] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [x] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?
No.

## Is this a breaking change?
No.

## Anything else?
Collaborators: Suggested using .NET default configuration + implemented: @bderusha 
This PR Closes Issue #134 
