### PR TITLE
JSON data source bugfix

### DIFF
--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/src/JsonDataSource.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/src/JsonDataSource.cs
@@ -26,8 +26,6 @@ public class JsonDataSource : ICarbonIntensityDataSource
 
     private readonly ILogger<JsonDataSource> _logger;
 
-    private const double DURATION = 8; // 8 hrs
-
     private IOptionsMonitor<JsonDataSourceConfiguration> _configurationMonitor { get; }
 
     private JsonDataSourceConfiguration _configuration => _configurationMonitor.CurrentValue;
@@ -56,7 +54,8 @@ public class JsonDataSource : ICarbonIntensityDataSource
         _logger.LogInformation("JSON data source getting carbon intensity for locations {locations} for period {periodStartTime} to {periodEndTime}.", locations, periodStartTime, periodEndTime);
 
         IEnumerable<EmissionsData>? emissionsData = await GetJsonDataAsync();
-        if (emissionsData == null || !emissionsData.Any()) {
+        if (emissionsData == null || !emissionsData.Any())
+        {
             _logger.LogDebug("Emission data list is empty");
             return Array.Empty<EmissionsData>();
         }
@@ -88,7 +87,7 @@ public class JsonDataSource : ICarbonIntensityDataSource
     {
         var (newStartTime, newEndTime) = IntervalHelper.ExtendTimeByWindow(startTime, endTime, MinSamplingWindow);
         var windowData = data.Where(ed => ed.TimeBetween(newStartTime, newEndTime));
-        var filteredData = IntervalHelper.FilterByDuration(windowData, startTime, endTime, TimeSpan.FromHours(DURATION));
+        var filteredData = IntervalHelper.FilterByDuration(windowData, startTime, endTime);
 
         if (!filteredData.Any())
         {
@@ -99,7 +98,7 @@ public class JsonDataSource : ICarbonIntensityDataSource
 
     private IEnumerable<EmissionsData> FilterByLocation(IEnumerable<EmissionsData> data, IEnumerable<string?> locations)
     {
-        if (locations.Any()) 
+        if (locations.Any())
         {
             data = data.Where(ed => locations.Contains(ed.Location));
         }
@@ -115,7 +114,8 @@ public class JsonDataSource : ICarbonIntensityDataSource
         }
         using Stream stream = GetStreamFromFileLocation();
         var jsonObject = await JsonSerializer.DeserializeAsync<EmissionsJsonFile>(stream);
-        if (_emissionsData is null || !_emissionsData.Any()) {
+        if (_emissionsData is null || !_emissionsData.Any())
+        {
             _emissionsData = jsonObject?.Emissions;
         }
         return _emissionsData;

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/test/JsonDataSourceTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/test/JsonDataSourceTests.cs
@@ -74,6 +74,24 @@ public class JsonDataSourceTests
 
     }
 
+    [Test]
+    public async Task GetCarbonIntensityAsync_ReturnsSingleDataPoint_WhenStartParamExactlyMatchesDataStart()
+    {
+        var mockDataSource = SetupMockDataSource();
+
+        var location = new Location() { Name = "midwest" };
+        var locations = new List<Location>() { location };
+        var start = DateTimeOffset.Parse("2022-09-07T12:45:11+00:00");
+        var end = DateTimeOffset.Parse("2022-09-07T13:45:11+00:00");
+        var dataSource = mockDataSource.Object;
+        var result = await dataSource.GetCarbonIntensityAsync(locations, start, end);
+        Assert.AreEqual(1, result.Count());
+
+        foreach (var r in result)
+        {
+            Assert.IsTrue(locations.Where(loc => loc.Name == r.Location).Any());
+        }
+    }
     private Mock<JsonDataSource> SetupMockDataSource() {
         var logger = Mock.Of<ILogger<JsonDataSource>>();
         var monitor = Mock.Of<IOptionsMonitor<JsonDataSourceConfiguration>>();
@@ -103,7 +121,18 @@ public class JsonDataSourceTests
                 },
                 new EmissionsData {
                     Location = "midwest",
-                    Time = DateTime.Parse("2021-05-01")
+                    Time = DateTime.Parse("2022-09-07T04:45:11+00:00"),
+                    Duration = TimeSpan.FromHours(8)
+                },
+                new EmissionsData {
+                    Location = "midwest",
+                    Time = DateTime.Parse("2022-09-07T12:45:11+00:00"),
+                    Duration = TimeSpan.FromHours(8)
+                },
+                new EmissionsData {
+                    Location = "midwest",
+                    Time = DateTime.Parse("2022-09-07T20:45:11+00:00"),
+                    Duration = TimeSpan.FromHours(8)
                 }
             };
     }

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/WattTimeDataSourceTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/WattTimeDataSourceTests.cs
@@ -257,7 +257,7 @@ public class WattTimeDataSourceTests
     /// Tests that if 'frequency' is not provided in the WattTime response of emission data, it is calculated from the first 2 data points, or defaulted to 0 if fewer than 2 data points are returned 
     /// </summary>
     [TestCase(new double[] { 300, 300 }, 300, null, TestName = "GetCarbonIntensity - for multiple data points, frequency is null for one data point ")]
-    [TestCase(new double[] { 0 }, null, TestName = "GetCarbonIntensity - for less than 2 data points, frequency is null for one data point ")]
+    [TestCase(new double[] { }, null, TestName = "GetCarbonIntensity - for less than 2 data points, frequency is null for one data point ")]
     [TestCase(new double[] { 300, 300 }, null, null, TestName = "GetCarbonIntensity - for multiple data points, frequency is null for all data points")]
     [TestCase(new double[] { 500 }, 500, TestName = "GetCarbonIntensity - frequency is not null")]
     [TestCase(new double[] { }, TestName = "GetCarbonIntensity - for zero data points, returns empty enumerable")]

--- a/src/CarbonAware/src/IntervalHelper.cs
+++ b/src/CarbonAware/src/IntervalHelper.cs
@@ -13,15 +13,12 @@ public static class IntervalHelper
     /// <param name="startTime">Original start time provided by user</param>
     /// <param name="endTime">Original end time provided by user</param>
     /// <returns>Filtered emissions data.</returns>
-    public static IEnumerable<EmissionsData> FilterByDuration(IEnumerable<EmissionsData> expandedData, DateTimeOffset startTime, DateTimeOffset endTime, TimeSpan duration = default)
+    public static IEnumerable<EmissionsData> FilterByDuration(IEnumerable<EmissionsData> expandedData, DateTimeOffset startTime, DateTimeOffset endTime)
     {
-        if (duration != default)
-        {   // constant duration
-            return expandedData.Where(d => (d.Time + duration) >= startTime && d.Time <= endTime);
-        }
-        return expandedData.Where(d => (d.Time + d.Duration) >= startTime && d.Time <= endTime);
+        return expandedData.Where(d => (d.Time + d.Duration) > startTime && d.Time <= endTime);
     }
 
+    
     /// <summary>
     /// Extends start and end times by subtracting/adding window respectively
     /// </summary>

--- a/src/CarbonAware/src/Model/Location.cs
+++ b/src/CarbonAware/src/Model/Location.cs
@@ -34,6 +34,14 @@ public class Location
     /// </summary>
     #nullable enable
     public string? RegionName { get; set; }
+
+    /// <summary>
+    /// Interim getters/setters until RegionName is fully replaced by Name.
+    /// </summary>
+    public string? Name {
+        get => RegionName;
+        set => RegionName = value;
+    }
     #nullable disable
 
     /// <summary>

--- a/src/CarbonAware/test/IntervalHelperTests.cs
+++ b/src/CarbonAware/test/IntervalHelperTests.cs
@@ -48,10 +48,6 @@ public class IntervalHelperTests
         var emptyResult = IntervalHelper.FilterByDuration(Enumerable.Empty<EmissionsData>(), startDateTimeOffset, endDateTimeOffset);
         Assert.False(emptyResult.Any());
 
-        // If pass in duration, will ignore data value. With 45 min duration, captures 3 data points
-        var constantDuration = IntervalHelper.FilterByDuration(data, startDateTimeOffset, endDateTimeOffset, TimeSpan.FromMinutes(45));
-        Assert.True(constantDuration.Count() == 3);
-
         // If don't pass in duration, will lookup value in data. WIth included 30 min duration, captures 2 data points
         var minWindowValid = IntervalHelper.FilterByDuration(data, startDateTimeOffset, endDateTimeOffset);
         Assert.True(minWindowValid.Count() == 2);


### PR DESCRIPTION
Issue Number: #155 

## Summary
Fixes JSON DataSource bug

## Changes

- Remove hardcoded default values for emissions data durations
- Update date filter to keep data points with ends that are `> start` filter time rather than `>= start` filter time.

## Checklist

- [x] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?
- [x] Added any new Tests? Yes
- [x] Documentation Updates Made? No
- [x] Are there any API Changes? No
- [x] This is not a breaking change. It is not

## Anything else?

CC: @pritipath @Willmish @vaughanknight 

This PR Closes Issue #155 
