### PR TITLE
Refactor data source config

### DIFF
--- a/.github/workflows/build-webapi.yaml
+++ b/.github/workflows/build-webapi.yaml
@@ -12,7 +12,6 @@ on:
 env:
   DOCKERFILE_PATH: "CarbonAware.WebApi/src/Dockerfile"
   HEALTH_ENDPOINT: "0.0.0.0:8080/health"
-  DATA_ENDPOINT: "0.0.0.0:8080/emissions/bylocation?location=eastus"
   DLL_FILE_PATH: "./bin/Release/net6.0/CarbonAware.WebApi.dll"
   DOTNET_SRC_DIR: "./src"
 
@@ -83,10 +82,6 @@ jobs:
       - name: Docker WGET Health Endpoint
         run: |
           wget -t 5 --waitretry=5 ${HEALTH_ENDPOINT}
-
-      - name: Docker WGET Data Endpoint
-        run: |
-          wget -t 5 --waitretry=5 ${DATA_ENDPOINT}
 
   api-comparison:
       needs: container-dotnet-build

--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -35,7 +35,7 @@ Please note that configuration is hierarchical.  The last configuration source l
 When adding values via environment variables, we recommend that you use the double underscore form, rather than the colon form.  Colons won't work in non-windows environment.  For example:
 
 ```bash
-  CarbonAwareVars__CarbonIntensityDataSource="WattTime"
+  CarbonAwareVars__EmissionsDataSource="WattTime"
 ```
 
 Note that double underscores are used to represent dotted notation or child elements that you see in the JSON below.  For example, to set proxy information using environment variables, you'd do this:
@@ -61,7 +61,8 @@ Used to configure specific values that affect how the application gets data and 
 ```json
 {
     "carbonAwareVars": {
-        "carbonIntensityDataSource": "",
+        "ForecastDataSource": "WattTime",
+        "EmissionsDataSource": "JSON",
         "webApiRoutePrefix": "",
         "proxy": {
             "useProxy": false,
@@ -73,13 +74,13 @@ Used to configure specific values that affect how the application gets data and 
 }
 ```
 
-##### carbonIntensityDataSource
+##### DataSource
 
-Must be one of the following: `None, JSON, WattTime`.  
+Each data source interface is configured with an underlying datasource. 
+
+Must be one of the following: `JSON, WattTime`.  
 
 If set to `WattTime`, WattTime configuration must also be supplied.
-
-`None` is the default, and if this value is supplied, an exception will be thrown at startup.
 
 `JSON` will result in the data being loaded from a [json file](./src/CarbonAware.DataSources.Json/test-data-azure-emissions.json) compiled into the project.  You should not use these values in production, since they are static and don't represent carbon intensity accurately.
 

--- a/src/CarbonAware.Aggregators/src/Configuration/ServiceCollectionExtensions.cs
+++ b/src/CarbonAware.Aggregators/src/Configuration/ServiceCollectionExtensions.cs
@@ -1,10 +1,10 @@
+using CarbonAware.Aggregators.Emissions;
+using CarbonAware.Aggregators.Forecast;
+using CarbonAware.DataSources.Configuration;
+using CarbonAware.Exceptions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using CarbonAware.Aggregators.CarbonAware;
-using CarbonAware.DataSources.Configuration;
-using CarbonAware.Aggregators.Emissions;
-using CarbonAware.Aggregators.Forecast;
 
 namespace CarbonAware.Aggregators.Configuration;
 
@@ -15,9 +15,25 @@ public static class ServiceCollectionExtensions
     /// </summary>
     public static IServiceCollection AddCarbonAwareEmissionServices(this IServiceCollection services, IConfiguration configuration)
     {
-        services.AddDataSourceService(configuration);
         services.TryAddSingleton<IForecastAggregator, ForecastAggregator>();
         services.TryAddSingleton<IEmissionsAggregator, EmissionsAggregator>();
+        services.AddDataSourceService(configuration);
         return services;
+    }
+
+    /// <summary>
+    /// Add services needed in order to pull data from a Carbon Intensity data source.
+    /// </summary>
+    public static bool TryAddCarbonAwareEmissionServices(this IServiceCollection services, IConfiguration configuration, out string? errorMessage)
+    {
+        try
+        {
+            services.AddCarbonAwareEmissionServices(configuration);
+        } catch (ConfigurationException e) {
+            errorMessage = e.Message;
+            return false;
+        }
+        errorMessage = null;
+        return true;
     }
 }

--- a/src/CarbonAware.Aggregators/src/Emissions/EmissionsAggregator.cs
+++ b/src/CarbonAware.Aggregators/src/Emissions/EmissionsAggregator.cs
@@ -3,19 +3,14 @@ using CarbonAware.Extensions;
 using CarbonAware.Interfaces;
 using CarbonAware.Model;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using static CarbonAware.Aggregators.CarbonAware.CarbonAwareParameters;
 
 namespace CarbonAware.Aggregators.Emissions;
 
 public class EmissionsAggregator : IEmissionsAggregator
 {
-    private static readonly ActivitySource Activity = new ActivitySource(nameof(EmissionsAggregator));
+    private static readonly ActivitySource Activity = new(nameof(EmissionsAggregator));
     private readonly ILogger<EmissionsAggregator> _logger;
     private readonly IEmissionsDataSource _dataSource;
 
@@ -76,7 +71,7 @@ public class EmissionsAggregator : IEmissionsAggregator
             _logger.LogInformation("Aggregator getting average carbon intensity from data source");
             var emissionData = await _dataSource.GetCarbonIntensityAsync(parameters.SingleLocation, start, end);
             var value = emissionData.AverageOverPeriod(start, end);
-            _logger.LogInformation($"Carbon Intensity Average: {value}");
+            _logger.LogInformation("Carbon Intensity Average: {value}", value);
 
             return value;
         }

--- a/src/CarbonAware.Aggregators/src/Emissions/IEmissionsAggregator.cs
+++ b/src/CarbonAware.Aggregators/src/Emissions/IEmissionsAggregator.cs
@@ -1,10 +1,5 @@
 ﻿using CarbonAware.Aggregators.CarbonAware;
 using CarbonAware.Model;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CarbonAware.Aggregators.Emissions;
 

--- a/src/CarbonAware.Aggregators/src/Forecast/ForecastAggregator.cs
+++ b/src/CarbonAware.Aggregators/src/Forecast/ForecastAggregator.cs
@@ -1,16 +1,16 @@
 ﻿
-using CarbonAware.Model;
-using static CarbonAware.Aggregators.CarbonAware.CarbonAwareParameters;
-using System.Diagnostics;
-using CarbonAware.Interfaces;
-using Microsoft.Extensions.Logging;
-using CarbonAware.Extensions;
 using CarbonAware.Aggregators.CarbonAware;
+using CarbonAware.Extensions;
+using CarbonAware.Interfaces;
+using CarbonAware.Model;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
+using static CarbonAware.Aggregators.CarbonAware.CarbonAwareParameters;
 
 namespace CarbonAware.Aggregators.Forecast;
 public class ForecastAggregator : IForecastAggregator
 {
-    private static readonly ActivitySource Activity = new ActivitySource(nameof(ForecastAggregator));
+    private static readonly ActivitySource Activity = new(nameof(ForecastAggregator));
     private readonly ILogger<ForecastAggregator> _logger;
     private readonly IForecastDataSource _dataSource;
 

--- a/src/CarbonAware.Aggregators/test/EmissionsAggregatorTests.cs
+++ b/src/CarbonAware.Aggregators/test/EmissionsAggregatorTests.cs
@@ -66,7 +66,7 @@ public class EmissionsAggregatorTests
         var results = (await this.Aggregator.GetEmissionsDataAsync(parameters)).ToList();
 
         //Assert   
-        Assert.AreEqual(results.Count(), 1);
+        Assert.AreEqual(results.Count, 1);
         Assert.AreEqual(results.First().Time, expectedTimeValue);
     }
 

--- a/src/CarbonAware.Aggregators/test/ForecastAggregatorTests.cs
+++ b/src/CarbonAware.Aggregators/test/ForecastAggregatorTests.cs
@@ -131,7 +131,7 @@ public class ForecastAggregatorTests
 
         var expectedData = new List<EmissionsData>();
         var expectedRatings = new double[] { 15.0, 25.0 };
-        for (var i = 0; i < expectedRatings.Count(); i++)
+        for (var i = 0; i < expectedRatings.Length; i++)
         {
             expectedData.Add(new EmissionsData() { Time = dataStartTime + i * TimeSpan.FromMinutes(dataTickSize), Location = locationName, Rating = expectedRatings[i], Duration = TimeSpan.FromMinutes(dataDuration) });
         }
@@ -165,7 +165,7 @@ public class ForecastAggregatorTests
 
         var expectedData = new List<EmissionsData>();
         var expectedRatings = new double[] { 10.0, 20.0, 30.0, 40.0 };
-        for (var i = 0; i < expectedRatings.Count(); i++)
+        for (var i = 0; i < expectedRatings.Length; i++)
         {
             expectedData.Add(new EmissionsData() { Time = dataStartTime + i * TimeSpan.FromMinutes(dataTickSize), Location = locationName, Rating = expectedRatings[i], Duration = TimeSpan.FromMinutes(dataDuration) });
         }

--- a/src/CarbonAware.CLI/src/Commands/Emissions/EmissionsCommand.cs
+++ b/src/CarbonAware.CLI/src/Commands/Emissions/EmissionsCommand.cs
@@ -2,7 +2,6 @@ using CarbonAware.Aggregators.CarbonAware;
 using CarbonAware.Aggregators.Emissions;
 using CarbonAware.CLI.Common;
 using CarbonAware.CLI.Model;
-using Microsoft.AspNetCore.Http;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;

--- a/src/CarbonAware.CLI/test/integrationTests/IntegrationTestingBase.cs
+++ b/src/CarbonAware.CLI/test/integrationTests/IntegrationTestingBase.cs
@@ -18,7 +18,8 @@ public abstract class IntegrationTestingBase
 {
     private string _executableName = "caw";
     internal DataSourceType _dataSource;
-    internal string? _dataSourceEnv;
+    internal string? _emissionsDataSourceEnv;
+    internal string? _forecastDataSourceEnv;
     protected IDataSourceMocker _dataSourceMocker;
     protected TestConsole _console = new();
 
@@ -28,7 +29,8 @@ public abstract class IntegrationTestingBase
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
     {
         _dataSource = dataSource;
-        _dataSourceEnv = Environment.GetEnvironmentVariable("CarbonAwareVars__CarbonIntensityDataSource");
+        _emissionsDataSourceEnv = Environment.GetEnvironmentVariable("CarbonAwareVars__EmissionsDataSource");
+        _forecastDataSourceEnv = Environment.GetEnvironmentVariable("CarbonAwareVars__ForecastDataSource");
     }
 
     protected async Task<int> InvokeCliAsync(string arguments)
@@ -90,13 +92,14 @@ public abstract class IntegrationTestingBase
         {
             case DataSourceType.JSON:
                 {
-                    Environment.SetEnvironmentVariable("CarbonAwareVars__CarbonIntensityDataSource", "JSON");
+                    Environment.SetEnvironmentVariable("CarbonAwareVars__EmissionsDataSource", "JSON");
                     _dataSourceMocker = new JsonDataSourceMocker();
                     break;
                 }
             case DataSourceType.WattTime:
                 {
-                    Environment.SetEnvironmentVariable("CarbonAwareVars__CarbonIntensityDataSource", "WattTime");
+                    Environment.SetEnvironmentVariable("CarbonAwareVars__EmissionsDataSource", "WattTime");
+                    Environment.SetEnvironmentVariable("CarbonAwareVars__ForecastDataSource", "WattTime");
                     _dataSourceMocker = new WattTimeDataSourceMocker();
                     break;
                 }
@@ -140,6 +143,7 @@ public abstract class IntegrationTestingBase
     public void TearDown()
     {
         _dataSourceMocker.Dispose();
-        Environment.SetEnvironmentVariable("CarbonAwareVars__CarbonIntensityDataSource", _dataSourceEnv);
+        Environment.SetEnvironmentVariable("CarbonAwareVars__EmissionsDataSource", _emissionsDataSourceEnv);
+        Environment.SetEnvironmentVariable("CarbonAwareVars__ForecastDataSource", _forecastDataSourceEnv);
     }
 }

--- a/src/CarbonAware.CLI/test/unitTests/Commands/Emissions/EmissionsCommandTests.cs
+++ b/src/CarbonAware.CLI/test/unitTests/Commands/Emissions/EmissionsCommandTests.cs
@@ -1,11 +1,9 @@
 using CarbonAware.Aggregators.CarbonAware;
 using CarbonAware.CLI.Commands.Emissions;
 using CarbonAware.Model;
-using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
-using System.Text.Json;
 
 namespace CarbonAware.CLI.UnitTests;
 

--- a/src/CarbonAware.CLI/test/unitTests/Commands/EmissionsForecasts/EmissionsForecastsComandTests.cs
+++ b/src/CarbonAware.CLI/test/unitTests/Commands/EmissionsForecasts/EmissionsForecastsComandTests.cs
@@ -1,5 +1,4 @@
 ﻿using CarbonAware.Aggregators.CarbonAware;
-using CarbonAware.CLI.Commands.Emissions;
 using CarbonAware.CLI.Commands.EmissionsForecasts;
 using CarbonAware.Model;
 using Moq;

--- a/src/CarbonAware.CLI/test/unitTests/TestBase.cs
+++ b/src/CarbonAware.CLI/test/unitTests/TestBase.cs
@@ -14,8 +14,8 @@ namespace CarbonAware.CLI.UnitTests;
 /// </summary>
 public abstract class TestBase
 {
-    protected Mock<IForecastAggregator> _mockForecastAggregator = new Mock<IForecastAggregator>();
-    protected Mock<IEmissionsAggregator> _mockEmissionsAggregator = new Mock<IEmissionsAggregator>();
+    protected Mock<IForecastAggregator> _mockForecastAggregator = new();
+    protected Mock<IEmissionsAggregator> _mockEmissionsAggregator = new();
 
     protected readonly TestConsole _console = new();
 

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/mock/CarbonAware.DataSources.Json.Mocks.csproj
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/mock/CarbonAware.DataSources.Json.Mocks.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\CarbonAware.DataSources.Mocks\mock\CarbonAware.DataSources.Mocks.csproj" />
+    <ProjectReference Include="..\src\CarbonAware.DataSources.Json.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/mock/JsonDataSourceMocker.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/mock/JsonDataSourceMocker.cs
@@ -1,11 +1,42 @@
-﻿using CarbonAware.DataSources.Mocks;
+﻿using CarbonAware.DataSources.Json.Configuration;
+using CarbonAware.DataSources.Mocks;
+using CarbonAware.Model;
+using System.Text.Json;
 
 namespace CarbonAware.DataSources.Json.Mocks;
 public class JsonDataSourceMocker : IDataSourceMocker
 {
     public JsonDataSourceMocker() { }
 
-    public void SetupDataMock(DateTimeOffset start, DateTimeOffset end, string location) { }
+    public void SetupDataMock(DateTimeOffset start, DateTimeOffset end, string location)
+    {
+        string path = new JsonDataSourceConfiguration().DataFileLocation;
+
+        var data = new List<EmissionsData>();
+        DateTimeOffset pointTime = start;
+        TimeSpan duration = TimeSpan.FromHours(8);
+
+        while (pointTime < end)
+        {
+            var newDataPoint = new EmissionsData()
+            {
+                Location = location,
+                Time = pointTime,
+                Rating = 999.99,
+                Duration = duration,
+            };
+            
+            data.Add(newDataPoint);
+            pointTime = newDataPoint.Time + duration;
+        }
+        
+        var json = new 
+        {
+            Emissions = data
+        };
+
+        File.WriteAllText(path, JsonSerializer.Serialize(json));
+    }
     public void SetupForecastMock() { }
     public void Initialize() { }
     public void Reset() { }

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/src/Configuration/ServiceCollectionExtensions.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/src/Configuration/ServiceCollectionExtensions.cs
@@ -1,21 +1,19 @@
+using CarbonAware.Interfaces;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using CarbonAware.Interfaces;
 
 namespace CarbonAware.DataSources.Json.Configuration;
 
 public static class ServiceCollectionExtensions
 {
-    public static void AddJsonDataSourceService(this IServiceCollection services, IConfiguration configuration)
+    public static void AddJsonEmissionsDataSource(this IServiceCollection services, IConfiguration configuration)
     {
         // configuring dependency injection to have config.
         services.Configure<JsonDataSourceConfiguration>(c =>
         {
             configuration.GetSection(JsonDataSourceConfiguration.Key).Bind(c);
         });
-        services.TryAddSingleton<IForecastDataSource, JsonDataSource>();
         services.TryAddSingleton<IEmissionsDataSource, JsonDataSource>();
-
     }
 }

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/src/JsonDataSource.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/src/JsonDataSource.cs
@@ -10,7 +10,7 @@ namespace CarbonAware.DataSources.Json;
 /// <summary>
 /// Represents a JSON data source.
 /// </summary>
-public class JsonDataSource : IEmissionsDataSource, IForecastDataSource
+public class JsonDataSource : IEmissionsDataSource
 {
     public string Name => "JsonDataSource";
 
@@ -71,16 +71,6 @@ public class JsonDataSource : IEmissionsDataSource, IForecastDataSource
         }
 
         return emissionsData;
-    }
-
-    public Task<EmissionsForecast> GetCurrentCarbonIntensityForecastAsync(Location location)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<EmissionsForecast> GetCarbonIntensityForecastAsync(Location location, DateTimeOffset generatedAt)
-    {
-        throw new NotImplementedException();
     }
 
     private IEnumerable<EmissionsData> FilterByDateRange(IEnumerable<EmissionsData> data, DateTimeOffset startTime, DateTimeOffset endTime)

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/test/JsonDataSourceTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/test/JsonDataSourceTests.cs
@@ -65,16 +65,6 @@ public class JsonDataSourceTests
     }
 
     [Test]
-    public void GetCurrentCarbonIntensityForecastAsync_NotImplemented()
-    {
-        var mockDataSource = SetupMockDataSource();
-        var dataSource = mockDataSource.Object;
-        var location = new Location {Name = "paris"};
-        Assert.ThrowsAsync<NotImplementedException>(async () => await  dataSource.GetCurrentCarbonIntensityForecastAsync(location));
-
-    }
-
-    [Test]
     public async Task GetCarbonIntensityAsync_ReturnsSingleDataPoint_WhenStartParamExactlyMatchesDataStart()
     {
         var mockDataSource = SetupMockDataSource();

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Registration/Configuration/ServiceCollectionExtensions.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Registration/Configuration/ServiceCollectionExtensions.cs
@@ -1,45 +1,78 @@
-using Microsoft.Extensions.DependencyInjection;
 using CarbonAware.DataSources.Json.Configuration;
 using CarbonAware.DataSources.WattTime.Configuration;
+using CarbonAware.Exceptions;
+using CarbonAware.Interfaces;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace CarbonAware.DataSources.Configuration;
 public static class ServiceCollectionExtensions
 {
-    public static void AddDataSourceService(this IServiceCollection services, IConfiguration configuration)
+    public static IServiceCollection AddDataSourceService(this IServiceCollection services, IConfiguration configuration)
     {
         // find all the Classes in the Assembly that implements AddEmissionServices method,
         // and added them here with the specific implementation class.
-        var envVars = configuration.GetSection(CarbonAwareVariablesConfiguration.Key).Get<CarbonAwareVariablesConfiguration>();
-        var dataSourceType = GetDataSourceTypeFromValue(envVars?.CarbonIntensityDataSource);
+        var carbonAwareConfig = configuration.GetSection(CarbonAwareVariablesConfiguration.Key).Get<CarbonAwareVariablesConfiguration>();
+        var forecastDataSource = GetDataSourceTypeFromValue(carbonAwareConfig?.ForecastDataSource);
+        var emissionsDataSource = GetDataSourceTypeFromValue(carbonAwareConfig?.EmissionsDataSource);
 
-        switch (dataSourceType)
+
+        switch (forecastDataSource)
         {
             case DataSourceType.JSON:
             {
-                    services.AddJsonDataSourceService(configuration);
-                    break;
+                throw new ArgumentException("JSON data source is not supported for forecast data");
             }
             case DataSourceType.WattTime:
             {
-                    services.AddWattTimeDataSourceService(configuration);
-                    break;
+                services.AddWattTimeForecastDataSource(configuration);
+                break;
             }
             case DataSourceType.None:
             {
-                throw new NotSupportedException($"DataSourceType {dataSourceType.ToString()} not supported");
+                services.TryAddSingleton<IForecastDataSource, NullForecastDataSource>();
+                break;
             }
         }
+
+        switch (emissionsDataSource)
+        {
+            case DataSourceType.JSON:
+            {
+                services.AddJsonEmissionsDataSource(configuration);
+                break;
+            }
+            case DataSourceType.WattTime:
+            {
+                services.AddWattTimeEmissionsDataSource(configuration);
+                break;
+            }
+            case DataSourceType.None:
+            {
+                services.TryAddSingleton<IEmissionsDataSource, NullEmissionsDataSource>();
+                break;
+            }
+        }
+
+        if (forecastDataSource == DataSourceType.None && emissionsDataSource == DataSourceType.None)
+        {
+            throw new ConfigurationException("No data sources are configured");
+        }
+        
+        return services;
     }
+
     private static DataSourceType GetDataSourceTypeFromValue(string? srcVal)
     {
         DataSourceType result;
-        if (String.IsNullOrEmpty(srcVal) ||
-            !Enum.TryParse<DataSourceType>(srcVal, true, out result))
+        if (String.IsNullOrWhiteSpace(srcVal))
         {
-            // defaults to JSON in case env is empty, null or parsing fails
-            return DataSourceType.JSON;
+            result = DataSourceType.None;
+        }
+        else if (!Enum.TryParse<DataSourceType>(srcVal, true, out result))
+        {
+            throw new ArgumentException($"Unknown data source type: {srcVal}");
         }
         return result;
     }

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/src/Configuration/ServiceCollectionExtensions.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/src/Configuration/ServiceCollectionExtensions.cs
@@ -10,13 +10,23 @@ namespace CarbonAware.DataSources.WattTime.Configuration;
 
 public static class ServiceCollectionExtensions
 {
-    public static void AddWattTimeDataSourceService(this IServiceCollection services, IConfiguration? configuration)
+    public static void AddWattTimeForecastDataSource(this IServiceCollection services, IConfiguration? configuration)
+    {
+        _ = configuration ?? throw new ConfigurationException("WattTime configuration required.");
+        services.ConfigureWattTimeClient(configuration);
+        services.TryAddSingleton<IForecastDataSource, WattTimeDataSource>();
+        services.Configure<LocationDataSourcesConfiguration>(c =>
+        {
+            configuration.GetSection(LocationDataSourcesConfiguration.Key).Bind(c);
+        });
+        services.TryAddSingleton<ILocationSource, LocationSource>();
+    }
+
+    public static void AddWattTimeEmissionsDataSource(this IServiceCollection services, IConfiguration? configuration)
     {
         _ = configuration ?? throw new ConfigurationException("WattTime configuration required.");
         services.ConfigureWattTimeClient(configuration);
         services.TryAddSingleton<IEmissionsDataSource, WattTimeDataSource>();
-        services.TryAddSingleton<IForecastDataSource, WattTimeDataSource>();
-        // configuring dependency injection to have config.
         services.Configure<LocationDataSourcesConfiguration>(c =>
         {
             configuration.GetSection(LocationDataSourcesConfiguration.Key).Bind(c);

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/src/WattTimeDataSource.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/src/WattTimeDataSource.cs
@@ -5,6 +5,7 @@ using CarbonAware.Tools.WattTimeClient;
 using CarbonAware.Tools.WattTimeClient.Model;
 using Microsoft.Extensions.Logging;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace CarbonAware.DataSources.WattTime;
 
@@ -195,7 +196,8 @@ public class WattTimeDataSource : IEmissionsDataSource, IForecastDataSource
         try
         {
             var geolocation = await this.LocationSource.ToGeopositionLocationAsync(location);
-            balancingAuthority = await WattTimeClient.GetBalancingAuthorityAsync(geolocation.Latitude.ToString() ?? "", geolocation.Longitude.ToString() ?? "");
+            balancingAuthority = await WattTimeClient.GetBalancingAuthorityAsync(
+               Convert.ToString(geolocation.Latitude, CultureInfo.InvariantCulture) ?? "", Convert.ToString(geolocation.Longitude, CultureInfo.InvariantCulture) ?? "");
         }
         catch(Exception ex) when (ex is LocationConversionException ||  ex is WattTimeClientHttpException)
         {

--- a/src/CarbonAware.LocationSources/src/LocationSource.cs
+++ b/src/CarbonAware.LocationSources/src/LocationSource.cs
@@ -5,6 +5,7 @@ using CarbonAware.LocationSources.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Reflection;
+using System.Globalization;
 using System.Text.Json;
 
 namespace CarbonAware.LocationSources;
@@ -53,8 +54,8 @@ public class LocationSource : ILocationSource
         }
         return new Location
         {
-            Latitude = Convert.ToDecimal(geopositionLocation.Latitude),
-            Longitude = Convert.ToDecimal(geopositionLocation.Longitude)
+            Latitude = Convert.ToDecimal(geopositionLocation.Latitude, CultureInfo.InvariantCulture),
+            Longitude = Convert.ToDecimal(geopositionLocation.Longitude, CultureInfo.InvariantCulture)
         };
     }
 

--- a/src/CarbonAware.WebApi/test/integrationTests/CarbonAwareControllerTests.cs
+++ b/src/CarbonAware.WebApi/test/integrationTests/CarbonAwareControllerTests.cs
@@ -85,21 +85,6 @@ public class CarbonAwareControllerTests : IntegrationTestingBase
     }
 
     [Test]
-    public async Task EmissionsForecastsCurrent_UnsupportedDataSources_ReturnsNotImplemented()
-    {
-        IgnoreTestForDataSource("data source does implement '/emissions/forecasts/current'.", DataSourceType.WattTime);
-
-        var queryStrings = new Dictionary<string, string>();
-        queryStrings["location"] = "fakeLocation";
-
-        var endpointURI = ConstructUriWithQueryString(currentForecastURI, queryStrings);
-
-        var result = await _client.GetAsync(endpointURI);
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.NotImplemented));
-    }
-
-    [Test]
     public async Task EmissionsForecastsCurrent_SupportedDataSources_ReturnsOk()
     {
         IgnoreTestForDataSource("data source does not implement '/emissions/forecasts/current'", DataSourceType.JSON);

--- a/src/CarbonAware.WebApi/test/integrationTests/IntegrationTestingBase.cs
+++ b/src/CarbonAware.WebApi/test/integrationTests/IntegrationTestingBase.cs
@@ -18,7 +18,8 @@ namespace CarbonAware.WebApi.IntegrationTests;
 public abstract class IntegrationTestingBase
 {
     internal DataSourceType _dataSource;
-    internal string? _dataSourceEnv;
+    internal string? _emissionsDataSourceEnv;
+    internal string? _forecastDataSourceEnv;
     internal WebApplicationFactory<Program> _factory;
     protected HttpClient _client;
     protected IDataSourceMocker _dataSourceMocker;
@@ -29,7 +30,8 @@ public abstract class IntegrationTestingBase
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
     {
         _dataSource = dataSource;
-        _dataSourceEnv = null;
+        _emissionsDataSourceEnv = null;
+        _forecastDataSourceEnv = null;
         _factory = new WebApplicationFactory<Program>();
     }
 
@@ -72,7 +74,8 @@ public abstract class IntegrationTestingBase
     [OneTimeSetUp]
     public void Setup()
     {
-        _dataSourceEnv = Environment.GetEnvironmentVariable("CarbonAwareVars__CarbonIntensityDataSource");
+        _emissionsDataSourceEnv = Environment.GetEnvironmentVariable("CarbonAwareVars__EmissionsDataSource");
+        _forecastDataSourceEnv = Environment.GetEnvironmentVariable("CarbonAwareVars__ForecastDataSource");
 
         //Switch between different data sources as needed
         //Each datasource should have an accompanying DataSourceMocker that will perform setup activities
@@ -80,7 +83,7 @@ public abstract class IntegrationTestingBase
         {
             case DataSourceType.JSON:
                 {
-                    Environment.SetEnvironmentVariable("CarbonAwareVars__CarbonIntensityDataSource", "JSON");
+                    Environment.SetEnvironmentVariable("CarbonAwareVars__EmissionsDataSource", "JSON");
                     Environment.SetEnvironmentVariable("CarbonAwareVars__VerboseApi", "true");
                     Environment.SetEnvironmentVariable("JsonDataSourceConfiguration__DataFileLocation", "demo.json");
                     _dataSourceMocker = new JsonDataSourceMocker();
@@ -88,7 +91,8 @@ public abstract class IntegrationTestingBase
                 }
             case DataSourceType.WattTime:
                 {
-                    Environment.SetEnvironmentVariable("CarbonAwareVars__CarbonIntensityDataSource", "WattTime");
+                    Environment.SetEnvironmentVariable("CarbonAwareVars__EmissionsDataSource", "WattTime");
+                    Environment.SetEnvironmentVariable("CarbonAwareVars__ForecastDataSource", "WattTime");
                     _dataSourceMocker = new WattTimeDataSourceMocker();
                     break;
                 }
@@ -120,6 +124,7 @@ public abstract class IntegrationTestingBase
         _client.Dispose();
         _factory.Dispose();
         _dataSourceMocker.Dispose();
-        Environment.SetEnvironmentVariable("CarbonAwareVars__CarbonIntensityDataSource", _dataSourceEnv);
+        Environment.SetEnvironmentVariable("CarbonAwareVars__EmissionsDataSource", _emissionsDataSourceEnv);
+        Environment.SetEnvironmentVariable("CarbonAwareVars__ForecastDataSource", _forecastDataSourceEnv);
     }
 }

--- a/src/CarbonAware.WebApi/test/unitTests/CarbonAwareControllerTests.cs
+++ b/src/CarbonAware.WebApi/test/unitTests/CarbonAwareControllerTests.cs
@@ -1,6 +1,5 @@
 namespace CarbonAware.WepApi.UnitTests;
 
-using CarbonAware.Aggregators;
 using CarbonAware.Aggregators.CarbonAware;
 using CarbonAware.Aggregators.Emissions;
 using CarbonAware.Aggregators.Forecast;
@@ -12,9 +11,7 @@ using Moq;
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.Net;
-using System.Text.Json;
 using System.Threading.Tasks;
-using static Microsoft.ApplicationInsights.MetricDimensionNames.TelemetryContext;
 
 /// <summary>
 /// Tests that the Web API controller handles and packages various responses from a plugin properly 
@@ -23,7 +20,7 @@ using static Microsoft.ApplicationInsights.MetricDimensionNames.TelemetryContext
 [TestFixture]
 public class CarbonAwareControllerTests : TestsBase
 {
-    IForecastAggregator forecastAggregator = Mock.Of<IForecastAggregator>();
+    readonly IForecastAggregator forecastAggregator = Mock.Of<IForecastAggregator>();
     
     /// <summary>
     /// Tests that successful emissions call to an aggregator with any data returned results in action with OK status.

--- a/src/CarbonAware/src/CarbonAwareVariablesConfiguration.cs
+++ b/src/CarbonAware/src/CarbonAwareVariablesConfiguration.cs
@@ -18,9 +18,14 @@ public class CarbonAwareVariablesConfiguration
     public PathString WebApiRoutePrefix { get; set; }
 
     /// <summary>
-    /// Gets or sets the the carbon intensity data source to use.
+    /// Gets or sets the forecast data source to use.
     /// </summary>
-    public string CarbonIntensityDataSource { get; set; }
+    public string ForecastDataSource { get; set; }
+
+    /// <summary>
+    /// Gets or sets the emissions data source to use.
+    /// </summary>
+    public string EmissionsDataSource { get; set; }
 
     #nullable enable
     /// <summary>

--- a/src/CarbonAware/src/Exceptions/CarbonAwareException.cs
+++ b/src/CarbonAware/src/Exceptions/CarbonAwareException.cs
@@ -1,0 +1,31 @@
+namespace CarbonAware.Exceptions;
+
+/// <summary>
+/// Represents a CarbonAware project exception.
+/// </summary>
+public class CarbonAwareException : Exception
+{
+    /// <summary>
+    /// Creates a new instance of the <see cref="CarbonAwareException"/> class.
+    /// </summary>
+    public CarbonAwareException() : base()
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="CarbonAwareException"/> class.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    public CarbonAwareException(string message) : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="CarbonAwareException"/> class.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="innerException">The exception that caused the conversion exception.</param>
+    public CarbonAwareException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}

--- a/src/CarbonAware/src/Exceptions/ConfigurationException.cs
+++ b/src/CarbonAware/src/Exceptions/ConfigurationException.cs
@@ -1,0 +1,31 @@
+namespace CarbonAware.Exceptions;
+
+/// <summary>
+/// Represents a CarbonAware project exception.
+/// </summary>
+public class ConfigurationException : CarbonAwareException
+{
+    /// <summary>
+    /// Creates a new instance of the <see cref="ConfigurationException"/> class.
+    /// </summary>
+    public ConfigurationException() : base()
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="ConfigurationException"/> class.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    public ConfigurationException(string message) : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="ConfigurationException"/> class.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="innerException">The exception that caused the conversion exception.</param>
+    public ConfigurationException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}

--- a/src/CarbonAware/src/Interfaces/IEmissionsDataSource.cs
+++ b/src/CarbonAware/src/Interfaces/IEmissionsDataSource.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace CarbonAware.Interfaces;
+﻿namespace CarbonAware.Interfaces;
 
 public interface IEmissionsDataSource
 {

--- a/src/CarbonAware/src/Interfaces/IForecastDataSource.cs
+++ b/src/CarbonAware/src/Interfaces/IForecastDataSource.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-namespace CarbonAware.Interfaces;
+﻿namespace CarbonAware.Interfaces;
 public interface IForecastDataSource
 {
     /// <summary>

--- a/src/CarbonAware/src/NullEmissionsDataSource.cs
+++ b/src/CarbonAware/src/NullEmissionsDataSource.cs
@@ -1,5 +1,4 @@
 ﻿using CarbonAware.Interfaces;
-using CarbonAware.Model;
 
 namespace CarbonAware;
 
@@ -7,11 +6,11 @@ public class NullEmissionsDataSource : IEmissionsDataSource
 {
     public Task<IEnumerable<EmissionsData>> GetCarbonIntensityAsync(IEnumerable<Location> locations, DateTimeOffset periodStartTime, DateTimeOffset periodEndTime)
     {
-        return Task.FromResult(Enumerable.Empty<EmissionsData>());
+        throw new ArgumentException("EmissionsDataSource is not configured");
     }
 
     public Task<IEnumerable<EmissionsData>> GetCarbonIntensityAsync(Location location, DateTimeOffset periodStartTime, DateTimeOffset periodEndTime)
     {
-        return Task.FromResult(Enumerable.Empty<EmissionsData>());
+        throw new ArgumentException("EmissionsDataSource is not configured");
     }
 }

--- a/src/CarbonAware/src/NullForecastDataSource.cs
+++ b/src/CarbonAware/src/NullForecastDataSource.cs
@@ -1,27 +1,16 @@
 ﻿using CarbonAware.Interfaces;
-using CarbonAware.Model;
 
 namespace CarbonAware;
 
 public class NullForecastDataSource : IForecastDataSource
 {
-    private static EmissionsForecast emissionsForecast = new EmissionsForecast()
-    {
-        RequestedAt = default,
-        GeneratedAt = default,
-        DataStartAt = default,
-        DataEndAt = default,
-        WindowSize = default,
-        OptimalDataPoints = Enumerable.Empty<EmissionsData>(),
-    };
-
     public Task<EmissionsForecast> GetCarbonIntensityForecastAsync(Location location, DateTimeOffset requestedAt)
     {
-        return Task.FromResult(emissionsForecast);
+        throw new ArgumentException("ForecastDataSource is not configured");
     }
 
     public Task<EmissionsForecast> GetCurrentCarbonIntensityForecastAsync(Location location)
     {
-        return Task.FromResult(emissionsForecast);
+        throw new ArgumentException("ForecastDataSource is not configured");
     }
 }


### PR DESCRIPTION
Issue Number: #170 

# DEPENDENT PR
> **Warning**
> This PR depends on commits in other PRs
> **DO NOT** merge this PR until #193 is merged and this branch is updated against the latest `dev` branch

## Use [THIS LINK](https://github.com/Green-Software-Foundation/carbon-aware-sdk/pull/188/commits/7adeedbd72f4028164b490a09cd1e8ca11db4830) to review only the code for this PR and hide the dependent commits

## Summary
Exposes the new data source interfaces in config so they can be configured separately.

## Changes

- Update `CarbonAwareVars` config to use `ForecastDataSource` and `EmissionsDataSource`
- Remove `CarbonAwareDataSource` from config
- Logs error if no data sources are configured instead of using a JSON default.
- Unconfigured data source will be set to the NullDataSource which throws a validation error if used.
- Removes `IForecastDataSource` interface from JSON data source

## Checklist

- [x] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?
- [x] Added any new Tests?
- [x] Documentation Updates Made?
- [x] Are there any API Changes? If yes, please describe below.
- [x] This is not a breaking change. If it is, please describe it below.

## Are there API Changes? No

## Is this a breaking change? Yes
If yes, what workflow does this break? 
- `CarbonAwareVars__CarbonAwareDataSource` values will not be used
- JSON will not be a default data source.

## Anything else?
Other comments, collaborators, etc.

This PR Closes #170 
