### PR TITLE
[Bug Fix] Integration Tests + Location string need to be CultureInvariant

### DIFF
--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/mock/CarbonAware.DataSources.Json.Mocks.csproj
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/mock/CarbonAware.DataSources.Json.Mocks.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\CarbonAware.DataSources.Mocks\mock\CarbonAware.DataSources.Mocks.csproj" />
+    <ProjectReference Include="..\src\CarbonAware.DataSources.Json.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/mock/JsonDataSourceMocker.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/mock/JsonDataSourceMocker.cs
@@ -1,11 +1,42 @@
-﻿using CarbonAware.DataSources.Mocks;
+﻿using CarbonAware.DataSources.Json.Configuration;
+using CarbonAware.DataSources.Mocks;
+using CarbonAware.Model;
+using System.Text.Json;
 
 namespace CarbonAware.DataSources.Json.Mocks;
 public class JsonDataSourceMocker : IDataSourceMocker
 {
     public JsonDataSourceMocker() { }
 
-    public void SetupDataMock(DateTimeOffset start, DateTimeOffset end, string location) { }
+    public void SetupDataMock(DateTimeOffset start, DateTimeOffset end, string location)
+    {
+        string path = new JsonDataSourceConfiguration().DataFileLocation;
+
+        var data = new List<EmissionsData>();
+        DateTimeOffset pointTime = start;
+        TimeSpan duration = TimeSpan.FromHours(8);
+
+        while (pointTime < end)
+        {
+            var newDataPoint = new EmissionsData()
+            {
+                Location = location,
+                Time = pointTime,
+                Rating = 999.99,
+                Duration = duration,
+            };
+            
+            data.Add(newDataPoint);
+            pointTime = newDataPoint.Time + duration;
+        }
+        
+        var json = new 
+        {
+            Emissions = data
+        };
+
+        File.WriteAllText(path, JsonSerializer.Serialize(json));
+    }
     public void SetupForecastMock() { }
     public void Initialize() { }
     public void Reset() { }

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/src/WattTimeDataSource.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/src/WattTimeDataSource.cs
@@ -5,6 +5,7 @@ using CarbonAware.Tools.WattTimeClient;
 using CarbonAware.Tools.WattTimeClient.Model;
 using Microsoft.Extensions.Logging;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace CarbonAware.DataSources.WattTime;
 
@@ -195,7 +196,8 @@ public class WattTimeDataSource : ICarbonIntensityDataSource
         try
         {
             var geolocation = await this.LocationSource.ToGeopositionLocationAsync(location);
-            balancingAuthority = await WattTimeClient.GetBalancingAuthorityAsync(geolocation.Latitude.ToString() ?? "", geolocation.Longitude.ToString() ?? "");
+            balancingAuthority = await WattTimeClient.GetBalancingAuthorityAsync(
+               Convert.ToString(geolocation.Latitude, CultureInfo.InvariantCulture) ?? "", Convert.ToString(geolocation.Longitude, CultureInfo.InvariantCulture) ?? "");
         }
         catch(Exception ex) when (ex is LocationConversionException ||  ex is WattTimeClientHttpException)
         {

--- a/src/CarbonAware.LocationSources/src/LocationSource.cs
+++ b/src/CarbonAware.LocationSources/src/LocationSource.cs
@@ -5,6 +5,7 @@ using CarbonAware.LocationSources.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Reflection;
+using System.Globalization;
 using System.Text.Json;
 
 namespace CarbonAware.LocationSources;
@@ -53,8 +54,8 @@ public class LocationSource : ILocationSource
         }
         return new Location
         {
-            Latitude = Convert.ToDecimal(geopositionLocation.Latitude),
-            Longitude = Convert.ToDecimal(geopositionLocation.Longitude)
+            Latitude = Convert.ToDecimal(geopositionLocation.Latitude, CultureInfo.InvariantCulture),
+            Longitude = Convert.ToDecimal(geopositionLocation.Longitude, CultureInfo.InvariantCulture)
         };
     }
 


### PR DESCRIPTION
Issue Number: #192 

## Summary
When sending the geo location request with latitude and longitude the decimal is not forwarded to WattTime.

## Changes

- Add `InvariantCulture` to location string ops

## Checklist

- [X] Local Tests Passing?
- [X] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [ ] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?
If yes, what are the expected API Changes? Please link to an API-Comparison workflow with the API Diff.

## Is this a breaking change?
If yes, what workflow does this break? 

## Anything else?
Other comments, collaborators, etc.
> Please follow [GitHub's suggested syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to link Pull Requests to Issues via keywords

This PR Closes #192
