### PR TITLE
Handle duplicated Location keys

### DIFF
--- a/src/CarbonAware.LocationSources/src/LocationSource.cs
+++ b/src/CarbonAware.LocationSources/src/LocationSource.cs
@@ -1,4 +1,3 @@
-using CarbonAware.Exceptions;
 using CarbonAware.Interfaces;
 using CarbonAware.Model;
 using CarbonAware.LocationSources.Configuration;
@@ -6,7 +5,6 @@ using CarbonAware.LocationSources.Model;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Reflection;
-using System.Globalization;
 using System.Text.Json;
 
 namespace CarbonAware.LocationSources;
@@ -48,7 +46,7 @@ public class LocationSource : ILocationSource
             throw new ArgumentException($"Unknown Location: '{name}' not found");
         }
 
-        var geopositionLocation = _namedGeopositions[name];    
+        var geopositionLocation = _namedGeopositions[name];
         geopositionLocation.AssertValid(name);
 
         return (Location) geopositionLocation;
@@ -56,6 +54,7 @@ public class LocationSource : ILocationSource
 
     private async Task LoadLocationJsonFileAsync()
     {
+        var keyCounter = new Dictionary<string, int>();
         var sourceFiles = !_configuration.LocationSourceFiles.Any() ? DiscoverFiles() : _configuration.LocationSourceFiles;
         foreach (var source in sourceFiles)
         {
@@ -64,7 +63,7 @@ public class LocationSource : ILocationSource
             foreach (var locationName in locationMapping.Keys) 
             {
                 var key = BuildKey(source, locationName);
-                _namedGeopositions[key] = locationMapping[locationName];
+                AddToDictionary(key, locationMapping[locationName], source.DataFileLocation, keyCounter);
             }
         }
     }
@@ -98,13 +97,44 @@ public class LocationSource : ILocationSource
         var assemblyDirectory = Path.GetDirectoryName(assemblyPath)!;
 
         var pathCombined = Path.Combine(assemblyDirectory, LocationSourceFile.BaseDirectory);
-        var files = Directory.GetFiles(pathCombined, "*.json", SearchOption.AllDirectories);
+        var files = Directory.GetFiles(pathCombined, "*.json", SearchOption.AllDirectories).OrderBy(f => f);
         if (files is null)
         {
             _logger.LogWarning($"No location files found under {pathCombined}");
             return Array.Empty<LocationSourceFile>();
         }
-        _logger.LogInformation($"{files.Length} files discovered");
+        _logger.LogInformation($"{files.Count()} files discovered");
         return files.Select(x => x.Substring(pathCombined.Length + 1)).Select(n => new LocationSourceFile { DataFileLocation = n });
+    }
+
+    private void AddToDictionary(string key, NamedGeoposition data, string sourceFile, Dictionary<string, int> keyCounter)
+    {
+        if (_namedGeopositions.TryAdd(key, data))
+        {
+            keyCounter.Add(key, 0);
+            return;
+        }
+        _logger.LogWarning("Location key {key} from {sourceFile} already exists", key, sourceFile);
+        var (newKey, counter) = GenKeyAndCounter(key, keyCounter);
+        if (!_namedGeopositions.TryAdd(newKey, data))
+        {
+            _logger.LogError($"New Location key {newKey} already exists", newKey);
+            return;
+        }
+        // update key counter dict
+        keyCounter[key] = counter;
+        _logger.LogWarning("New Location key {newKey} added for {sourceFile}", newKey, sourceFile);
+    }
+
+    private (string, int) GenKeyAndCounter(string key, Dictionary<string, int> keyCounter)
+    {
+        if (!keyCounter.TryGetValue(key, out var value))
+        {
+            throw new ArgumentException($"Key {key} not found on key counter dictionary");
+        }
+        value++;
+        var newKey = $"{key}_{value}";
+        _logger.LogDebug("New key {newKey} generated from {key}", newKey, key);
+        return (newKey, value);
     }
 }

--- a/src/CarbonAware.LocationSources/test/TestConstants.cs
+++ b/src/CarbonAware.LocationSources/test/TestConstants.cs
@@ -34,15 +34,9 @@ public static class Constants
                     Latitude = 37.783m,
                     Longitude = -121.417m
                 };
-    public static readonly Location LocationNorthCentral = new () {
-                    Name = "test-northcentralus",
-                    Latitude = 37.783m,
-                    Longitude = -120.417m
-                };
     public static readonly Location FakeLocation = new () {
                     Name = "",
                     Latitude = 0.0m,
                     Longitude = 0.0m
                     };
-
 }


### PR DESCRIPTION
Issue Number: (214)

Close microsoft/carbon-aware-sdk#214

## Summary
Handle scenarios where location files with the same `NamedGeoposition` key can be overwritten by another file.

## Changes

- Rename dup keys to allow to be all loaded, avoiding name collision and user missing Geoposition instances.
-  For instance:
    - If a there is a Geoposition `eastus` on `file1.json` and in `file2.json`, loading both files, it would ensure that both Geopositions are loaded. `eastus` on `file2.json` can be indexed as `eastus_1`. User could now retrieve that instance using `eastus_1` instead of not be able to find it (current behavior). If there is another one, on a 3rd file, it would be `eastus_2` and so on.

## Checklist

- [x] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?
- [x] Added any new Tests?


