### PR TITLE
Update clients to use Moq infrastrucutre for HTTP requests

### DIFF
--- a/src/CarbonAware.CLI/src/Commands/Location/LocalizableStrings.Designer.cs
+++ b/src/CarbonAware.CLI/src/Commands/Location/LocalizableStrings.Designer.cs
@@ -61,7 +61,7 @@ namespace CarbonAware.CLI.Commands.Location {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Returns all the supported locations.
+        ///   Looks up a localized string similar to Returns all the supported locations .
         /// </summary>
         internal static string LocationsCommandDescription {
             get {

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMaps/test/CarbonAware.DataSources.ElectricityMaps.Tests.csproj
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMaps/test/CarbonAware.DataSources.ElectricityMaps.Tests.csproj
@@ -19,7 +19,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Moq" Version="4.17.2" />
-	  <PackageReference Include="Moq.Contrib.HttpClient" Version="1.4.0" />
+    <PackageReference Include="Moq.Contrib.HttpClient" Version="1.4.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMaps/test/CarbonAware.DataSources.ElectricityMaps.Tests.csproj
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMaps/test/CarbonAware.DataSources.ElectricityMaps.Tests.csproj
@@ -17,11 +17,12 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-    <PackageReference Include="Moq"/>
-    <PackageReference Include="NUnit"/>
-    <PackageReference Include="NUnit3TestAdapter"/>
-    <PackageReference Include="NUnit.Analyzers"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Moq" Version="4.17.2" />
+	  <PackageReference Include="Moq.Contrib.HttpClient" Version="1.4.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMaps/test/Client/ElectricityMapsClientTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMaps/test/Client/ElectricityMapsClientTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Moq.Protected;
+using Moq.Contrib.HttpClient;
 using System.Text.Json;
 
 namespace CarbonAware.DataSources.ElectricityMaps.Tests;
@@ -14,17 +15,13 @@ namespace CarbonAware.DataSources.ElectricityMaps.Tests;
 [TestFixture]
 public class ElectricityMapsClientTests
 {
-
     private readonly string AuthHeader = "auth-token";
     private readonly string DefaultTokenValue = "myDefaultToken123";
-
     private readonly string TestLatitude = "36.6681";
     private readonly string TestLongitude = "-78.3889";
     private readonly string TestZone = "NL";
 
-    private MockHttpMessageHandler MessageHandler { get; set; }
-
-    private HttpClient HttpClient { get; set; }
+    private Mock<HttpMessageHandler> Handler { get; set; }
 
     private IHttpClientFactory HttpClientFactory { get; set; }
 
@@ -43,6 +40,15 @@ public class ElectricityMapsClientTests
         this.Log = new Mock<ILogger<ElectricityMapsClient>>();
 
         this.Options.Setup(o => o.CurrentValue).Returns(() => this.Configuration);
+
+        this.Handler = new Mock<HttpMessageHandler>();
+        this.HttpClientFactory = Handler.CreateClientFactory();
+        Mock.Get(this.HttpClientFactory).Setup(x => x.CreateClient(IElectricityMapsClient.NamedClient))
+            .Returns(() =>
+            {
+                var client = Handler.CreateClient();
+                return client;
+            });
     }
 
     [TestCase(BaseUrls.TrialBaseUrl, TestName = "ClientInstantiation_FailsForInvalidConfig: Trial")]
@@ -50,7 +56,7 @@ public class ElectricityMapsClientTests
     public void ClientInstantiation_FailsForInvalidConfig(string baseUrl)
     {
         // Arrange
-        CreateBasicClient(TestData.GetZonesAllowedJsonString(), "{}");
+        AddHandlers_Auth_Zones(TestData.GetZonesAllowedJsonString());
         this.Configuration = new ElectricityMapsClientConfiguration()
         {
             APITokenHeader = string.Empty,
@@ -67,7 +73,7 @@ public class ElectricityMapsClientTests
     public void ClientInstantiation_SucceedsForValidConfig(string baseUrl)
     {
         // Arrange
-        CreateBasicClient(TestData.GetZonesAllowedJsonString(), "{}");
+        AddHandlers_Auth_Zones(TestData.GetZonesAllowedJsonString());
         this.Configuration.BaseUrl = baseUrl;
 
         // Act & Assert
@@ -107,7 +113,12 @@ public class ElectricityMapsClientTests
     public void GetForecastedCarbonIntensityAsync_ThrowsWhenBadJsonIsReturned()
     {
         // Arrange
-        CreateBasicClient(TestData.GetZonesAllowedJsonString(), "This is bad json");
+        AddHandlers_Auth_Zones(TestData.GetZonesAllowedJsonString());
+        AddHandler_RequestResponse(r =>
+        {
+            return r.RequestUri!.ToString().Contains(BaseUrls.TokenBaseUrl + Paths.Forecast) && r.Method == HttpMethod.Get;
+        }, System.Net.HttpStatusCode.OK, "This is bad json");
+
         var client = new ElectricityMapsClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
 
         // Act & Assert
@@ -118,7 +129,12 @@ public class ElectricityMapsClientTests
     public void GetForecastedCarbonIntensityAsync_ThrowsWhenNull()
     {
         // Arrange
-        CreateBasicClient(TestData.GetZonesAllowedJsonString(), "null");
+        AddHandlers_Auth_Zones(TestData.GetZonesAllowedJsonString());
+        AddHandler_RequestResponse(r =>
+        {
+            return r.RequestUri!.ToString().Contains(BaseUrls.TokenBaseUrl + Paths.Forecast) && r.Method == HttpMethod.Get;
+        }, System.Net.HttpStatusCode.OK, "null");
+
         var client = new ElectricityMapsClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
 
         // Act & Assert
@@ -129,7 +145,7 @@ public class ElectricityMapsClientTests
     public void GetForecastedCarbonIntensityAsync_ThrowsWhen_PathNotSupported()
     {
         // Arrange
-        CreateBasicClient(TestData.GetNoPathsSupportedJsonString(), string.Empty);
+        AddHandlers_Auth_Zones(TestData.GetNoPathsSupportedJsonString());
         var client = new ElectricityMapsClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
 
         // Act & Assert
@@ -140,7 +156,7 @@ public class ElectricityMapsClientTests
     public void GetForecastedCarbonIntensityAsync_ThrowsWhen_ZoneNotSupported()
     {
         // Arrange
-        CreateBasicClient(TestData.GetNoZonesSupportedJsonString(), string.Empty);
+        AddHandlers_Auth_Zones(TestData.GetNoZonesSupportedJsonString());
         var client = new ElectricityMapsClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
 
         // Act & Assert
@@ -154,22 +170,11 @@ public class ElectricityMapsClientTests
     {
         // Arrange
         this.Configuration.BaseUrl = baseUrl;
-        this.CreateHttpClient(m =>
-        {
-            if (m.RequestUri!.ToString() == baseUrl + Paths.Zones)
+        AddHandlers_Auth_Zones(TestData.GetZonesAllowedJsonString());
+        AddHandler_RequestResponse(r =>
             {
-                var response = this.MockElectricityMapsResponse(m, new StringContent(TestData.GetZonesAllowedJsonString()));
-                return Task.FromResult(response);
-            }
-            else if (
-                m.RequestUri!.ToString().Contains(baseUrl + Paths.Forecast) &&
-                m.Method == HttpMethod.Get)
-            {
-                var response = this.MockElectricityMapsResponse(m, new StringContent(TestData.GetCurrentForecastJsonString()));
-                return Task.FromResult(response);
-            }
-            return Task.FromResult(this.MockElectricityMapsResponse(m, new StringContent("null")));
-        });
+                return r.RequestUri!.ToString().Contains(baseUrl + Paths.Forecast) && r.Method == HttpMethod.Get;
+            }, System.Net.HttpStatusCode.OK, TestData.GetCurrentForecastJsonString());
 
         var client = new ElectricityMapsClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
 
@@ -189,7 +194,12 @@ public class ElectricityMapsClientTests
     public void GetRecentCarbonIntensityHistoryAsync_ThrowsWhenBadJsonIsReturned()
     {
         // Arrange
-        CreateBasicClient(TestData.GetZonesAllowedJsonString(), "This is bad json");
+        AddHandlers_Auth_Zones(TestData.GetZonesAllowedJsonString());
+        AddHandler_RequestResponse(r =>
+        {
+            return r.RequestUri!.ToString().Contains(BaseUrls.TokenBaseUrl + Paths.History) && r.Method == HttpMethod.Get;
+        }, System.Net.HttpStatusCode.OK, "This is bad json");
+
         var client = new ElectricityMapsClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
 
         // Act & Assert
@@ -200,7 +210,7 @@ public class ElectricityMapsClientTests
     public void GetRecentCarbonIntensityHistoryAsync_ThrowsWhen_PathNotSupported()
     {
         // Arrange
-        CreateBasicClient(TestData.GetNoPathsSupportedJsonString(), string.Empty);
+        AddHandlers_Auth_Zones(TestData.GetNoPathsSupportedJsonString());
         var client = new ElectricityMapsClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
 
         // Act & Assert
@@ -211,7 +221,7 @@ public class ElectricityMapsClientTests
     public void GetRecentCarbonIntensityHistoryAsync_ThrowsWhen_ZoneNotSupported()
     {
         // Arrange
-        CreateBasicClient(TestData.GetNoZonesSupportedJsonString(), string.Empty);
+        AddHandlers_Auth_Zones(TestData.GetNoZonesSupportedJsonString());
         var client = new ElectricityMapsClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
 
         // Act & Assert
@@ -224,20 +234,12 @@ public class ElectricityMapsClientTests
     {
         // Arrange
         this.Configuration.BaseUrl = baseUrl;
-        this.CreateHttpClient(m =>
-        {
-            if (m.RequestUri!.ToString() == baseUrl + Paths.Zones)
+
+        AddHandlers_Auth_Zones(TestData.GetZonesAllowedJsonString());
+        AddHandler_RequestResponse(r =>
             {
-                var response = this.MockElectricityMapsResponse(m, new StringContent(TestData.GetZonesAllowedJsonString()));
-                return Task.FromResult(response);
-            }
-            else if (m.RequestUri!.ToString().Contains(baseUrl + Paths.History) && m.Method == HttpMethod.Get)
-            {
-                var response = this.MockElectricityMapsResponse(m, new StringContent(TestData.GetHistoryCarbonIntensityDataJsonString()));
-                return Task.FromResult(response);
-            }
-            return Task.FromResult(this.MockElectricityMapsResponse(m, new StringContent("null")));
-        });
+                return r.RequestUri!.ToString().Contains(baseUrl + Paths.History) && r.Method == HttpMethod.Get;
+            }, System.Net.HttpStatusCode.OK, TestData.GetHistoryCarbonIntensityDataJsonString());
 
         var client = new ElectricityMapsClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
 
@@ -261,53 +263,38 @@ public class ElectricityMapsClientTests
         });
     }
 
-    private void CreateBasicClient(string zoneContent, string resultContent)
+
+    /**
+     * Helper to add client handlers for auth checking and for zone content response
+     */
+    private void AddHandlers_Auth_Zones(string zoneContent)
     {
-        this.CreateHttpClient(m =>
-        {
-            var isTokenAuthValid = m.RequestUri!.ToString().Contains(BaseUrls.TokenBaseUrl) && !m.Headers.Where(x => x.Key == "auth-token").Any();
-            var isTrialAuthValid = m.RequestUri!.ToString().Contains(BaseUrls.TrialBaseUrl) && !m.Headers.Where(x => x.Key == "X-BLOBR-KEY").Any();
-            // If no auth and token setup, return unauthorized
-            if (isTokenAuthValid || isTrialAuthValid)
+        AddHandler_RequestResponse(r =>
             {
-                return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.Unauthorized));
-            }
+                var isTokenAuthInvalid = r.RequestUri!.ToString().Contains(BaseUrls.TokenBaseUrl) && !r.Headers.Where(x => x.Key == "auth-token").Any();
+                var isTrialAuthInvalid = r.RequestUri!.ToString().Contains(BaseUrls.TrialBaseUrl) && !r.Headers.Where(x => x.Key == "X-BLOBR-KEY").Any();
+                // If no auth and token setup, return unauthorized
+                return isTokenAuthInvalid || isTrialAuthInvalid;
+            }, System.Net.HttpStatusCode.Unauthorized);
 
-            if (m.RequestUri?.ToString() == BaseUrls.TokenBaseUrl + Paths.Zones)
+        AddHandler_RequestResponse(r =>
             {
-                var response = this.MockElectricityMapsResponse(m, new StringContent(zoneContent));
-                return Task.FromResult(response);
-            }
-            return Task.FromResult(this.MockElectricityMapsResponse(m, new StringContent(resultContent)));
-        });
+                return r.RequestUri?.ToString() == BaseUrls.TokenBaseUrl + Paths.Zones;
+            }, System.Net.HttpStatusCode.OK, zoneContent);
     }
 
-    private HttpResponseMessage MockElectricityMapsResponse(HttpRequestMessage request, HttpContent responseContent)
-    {
-        var response = new HttpResponseMessage(System.Net.HttpStatusCode.OK);
-        response.Content = responseContent;
-        return response;
-    }
-
-    private void CreateHttpClient(Func<HttpRequestMessage, Task<HttpResponseMessage>> requestDelegate)
-    {
-        this.MessageHandler = new MockHttpMessageHandler(requestDelegate);
-        this.HttpClient = new HttpClient(this.MessageHandler);
-        this.HttpClientFactory = Mock.Of<IHttpClientFactory>();
-        Mock.Get(this.HttpClientFactory).Setup(h => h.CreateClient(IElectricityMapsClient.NamedClient)).Returns(this.HttpClient);
-    }
-
-    private class MockHttpMessageHandler : HttpMessageHandler
-    {
-        private Func<HttpRequestMessage, Task<HttpResponseMessage>> RequestDelegate { get; set; }
-
-        public MockHttpMessageHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> requestDelegate)
-        {
-            this.RequestDelegate = requestDelegate;
-        }
-        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            return await this.RequestDelegate.Invoke(request);
-        }
+    /**
+     * Helper to add client handler for request predicate and corresponding status code and response content
+     */
+    private void AddHandler_RequestResponse(Predicate<HttpRequestMessage> requestPredicate, System.Net.HttpStatusCode statusCode, string? responseContent = null) {
+        if (responseContent != null) {
+            this.Handler
+                .SetupRequest(requestPredicate)
+                .ReturnsResponse(statusCode, new StringContent(responseContent));
+        } else {
+            this.Handler
+                .SetupRequest(requestPredicate)
+                .ReturnsResponse(statusCode);
+        }    
     }
 }

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMaps/test/Client/ElectricityMapsClientTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMaps/test/Client/ElectricityMapsClientTests.cs
@@ -110,35 +110,47 @@ public class ElectricityMapsClientTests
     }
 
     [Test]
-    public void GetForecastedCarbonIntensityAsync_ThrowsWhenBadJsonIsReturned()
+    public void AllPublicMethods_ThrowsClientException_WhenNull()
     {
         // Arrange
         AddHandlers_Auth_Zones(TestData.GetZonesAllowedJsonString());
         AddHandler_RequestResponse(r =>
         {
-            return r.RequestUri!.ToString().Contains(BaseUrls.TokenBaseUrl + Paths.Forecast) && r.Method == HttpMethod.Get;
-        }, System.Net.HttpStatusCode.OK, "This is bad json");
+            return r.RequestUri!.ToString().Contains(Paths.Forecast) && r.Method == HttpMethod.Get;
+        }, System.Net.HttpStatusCode.OK, "null");
 
-        var client = new ElectricityMapsClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
-
-        // Act & Assert
-        Assert.ThrowsAsync<JsonException>(async () => await client.GetForecastedCarbonIntensityAsync(TestLatitude, TestLongitude));
-    }
-
-    [Test]
-    public void GetForecastedCarbonIntensityAsync_ThrowsWhenNull()
-    {
-        // Arrange
-        AddHandlers_Auth_Zones(TestData.GetZonesAllowedJsonString());
         AddHandler_RequestResponse(r =>
         {
-            return r.RequestUri!.ToString().Contains(BaseUrls.TokenBaseUrl + Paths.Forecast) && r.Method == HttpMethod.Get;
+            return r.RequestUri!.ToString().Contains(Paths.History) && r.Method == HttpMethod.Get;
         }, System.Net.HttpStatusCode.OK, "null");
 
         var client = new ElectricityMapsClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
 
         // Act & Assert
         Assert.ThrowsAsync<ElectricityMapsClientException>(async () => await client.GetForecastedCarbonIntensityAsync(TestLatitude, TestLongitude));
+        Assert.ThrowsAsync<ElectricityMapsClientException>(async () => await client.GetRecentCarbonIntensityHistoryAsync(TestLatitude, TestLongitude));
+    }
+
+    [Test]
+    public void AllPublicMethods_ThrowJsonException_WhenBadJsonIsReturned()
+    {
+        // Arrange
+        AddHandlers_Auth_Zones(TestData.GetZonesAllowedJsonString());
+        AddHandler_RequestResponse(r =>
+        {
+            return r.RequestUri!.ToString().Contains(Paths.Forecast) && r.Method == HttpMethod.Get;
+        }, System.Net.HttpStatusCode.OK, "This is bad json");
+
+        AddHandler_RequestResponse(r =>
+        {
+            return r.RequestUri!.ToString().Contains(Paths.History) && r.Method == HttpMethod.Get;
+        }, System.Net.HttpStatusCode.OK, "This is bad json");
+
+        var client = new ElectricityMapsClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
+
+        // Act & Assert
+        Assert.ThrowsAsync<JsonException>(async () => await client.GetForecastedCarbonIntensityAsync(TestLatitude, TestLongitude));
+        Assert.ThrowsAsync<JsonException>(async () => await client.GetRecentCarbonIntensityHistoryAsync(TestLatitude, TestLongitude));
     }
 
     [Test]
@@ -188,22 +200,6 @@ public class ElectricityMapsClientTests
         Assert.That(forecast?.Zone, Is.EqualTo(TestZone));
         Assert.That(forecastDataPoint?.DateTime, Is.EqualTo(new DateTimeOffset(2099, 1, 1, 0, 0, 0, TimeSpan.Zero)));
         Assert.That(forecastDataPoint?.CarbonIntensity, Is.EqualTo(999));
-    }
-
-    [Test]
-    public void GetRecentCarbonIntensityHistoryAsync_ThrowsWhenBadJsonIsReturned()
-    {
-        // Arrange
-        AddHandlers_Auth_Zones(TestData.GetZonesAllowedJsonString());
-        AddHandler_RequestResponse(r =>
-        {
-            return r.RequestUri!.ToString().Contains(BaseUrls.TokenBaseUrl + Paths.History) && r.Method == HttpMethod.Get;
-        }, System.Net.HttpStatusCode.OK, "This is bad json");
-
-        var client = new ElectricityMapsClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
-
-        // Act & Assert
-        Assert.ThrowsAsync<JsonException>(async () => await client.GetRecentCarbonIntensityHistoryAsync(TestLatitude, TestLongitude));
     }
 
     [Test]

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/CarbonAware.DataSources.WattTime.Tests.csproj
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/CarbonAware.DataSources.WattTime.Tests.csproj
@@ -8,11 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-    <PackageReference Include="Moq"/>
-    <PackageReference Include="NUnit"/>
-    <PackageReference Include="NUnit3TestAdapter"/>
-    <PackageReference Include="coverlet.collector">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="Moq.Contrib.HttpClient" Version="1.4.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/Client/WattTimeClientTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/Client/WattTimeClientTests.cs
@@ -78,16 +78,40 @@ public class WattTimeClientTests
     }
 
     [Test]
-    public void GetDataAsync_ThrowsWhenBadJsonIsReturned()
+    public void AllPublicMethods_ThrowClientException_WhenNull()
     {
-        this.SetupBasicHandlers("This is bad json.");
+        this.SetupBasicHandlers("null");
 
         var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
+        var ba = new BalancingAuthority() { Abbreviation = "balauth" };
 
-        Assert.ThrowsAsync<JsonException>(async () => await client.GetDataAsync("ba", new DateTimeOffset(), new DateTimeOffset()));
+        Assert.ThrowsAsync<WattTimeClientException>(async () => await client.GetBalancingAuthorityAsync("lat", "long"));
+        Assert.ThrowsAsync<WattTimeClientException>(async () => await client.GetDataAsync(ba.Abbreviation, new DateTimeOffset(), new DateTimeOffset()));
+        Assert.ThrowsAsync<WattTimeClientException>(async () => await client.GetDataAsync(ba, new DateTimeOffset(), new DateTimeOffset()));
+        Assert.ThrowsAsync<WattTimeClientException>(async () => await client.GetCurrentForecastAsync(ba.Abbreviation));
+        Assert.ThrowsAsync<WattTimeClientException>(async () => await client.GetCurrentForecastAsync(ba));
+        Assert.ThrowsAsync<WattTimeClientException>(async () => await client.GetForecastOnDateAsync(ba.Abbreviation, new DateTimeOffset()));
+        Assert.ThrowsAsync<WattTimeClientException>(async () => await client.GetForecastOnDateAsync(ba, new DateTimeOffset()));
     }
 
+    [Test]
+    public void AllPublicMethods_ThrowJsonException_WhenBadJsonIsReturned()
+    {
+        this.SetupBasicHandlers("This is bad json");
+
+        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
+        client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
+        var ba = new BalancingAuthority() { Abbreviation = "balauth" };
+
+        Assert.ThrowsAsync<JsonException>(async () => await client.GetBalancingAuthorityAsync("lat", "long"));
+        Assert.ThrowsAsync<JsonException>(async () => await client.GetDataAsync(ba.Abbreviation, new DateTimeOffset(), new DateTimeOffset()));
+        Assert.ThrowsAsync<JsonException>(async () => await client.GetDataAsync(ba, new DateTimeOffset(), new DateTimeOffset()));
+        Assert.ThrowsAsync<JsonException>(async () => await client.GetCurrentForecastAsync(ba.Abbreviation));
+        Assert.ThrowsAsync<JsonException>(async () => await client.GetCurrentForecastAsync(ba));
+        Assert.ThrowsAsync<JsonException>(async () => await client.GetForecastOnDateAsync(ba.Abbreviation, new DateTimeOffset()));
+        Assert.ThrowsAsync<JsonException>(async () => await client.GetForecastOnDateAsync(ba, new DateTimeOffset()));
+    }
 
     [Test]
     public async Task GetDataAsync_DeserializesExpectedResponse()
@@ -141,32 +165,6 @@ public class WattTimeClientTests
         Assert.IsTrue(data.Count() > 0);
         var gridDataPoint = data.ToList().First();
         Assert.AreEqual("ba", gridDataPoint.BalancingAuthorityAbbreviation);
-    }
-
-    [Test]
-    public void GetCurrentForecastAsync_ThrowsWhenBadJsonIsReturned()
-    {
-        this.SetupBasicHandlers("This is bad json.");
-
-        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
-        client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
-        var ba = new BalancingAuthority() { Abbreviation = "balauth" };
-
-        Assert.ThrowsAsync<JsonException>(async () => await client.GetCurrentForecastAsync(ba.Abbreviation));
-        Assert.ThrowsAsync<JsonException>(async () => await client.GetCurrentForecastAsync(ba));
-    }
-
-    [Test]
-    public void GetCurrentForecastAsync_ThrowsWhenNull()
-    {
-        this.SetupBasicHandlers("null");
-
-        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
-        client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
-        var ba = new BalancingAuthority() { Abbreviation = "balauth" };
-
-        Assert.ThrowsAsync<WattTimeClientException>(async () => await client.GetCurrentForecastAsync(ba.Abbreviation));
-        // Assert.ThrowsAsync<WattTimeClientException>(async () => await client.GetCurrentForecastAsync(ba));
     }
 
     [Test]
@@ -238,32 +236,6 @@ public class WattTimeClientTests
     }
 
     [Test]
-    public void GetForecastOnDateAsync_ThrowsWhenBadJsonIsReturned()
-    {
-        this.SetupBasicHandlers("This is bad json.");
-
-        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
-        client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
-        var ba = new BalancingAuthority() { Abbreviation = "balauth" };
-
-        Assert.ThrowsAsync<JsonException>(async () => await client.GetForecastOnDateAsync(ba.Abbreviation, new DateTimeOffset()));
-        Assert.ThrowsAsync<JsonException>(async () => await client.GetForecastOnDateAsync(ba, new DateTimeOffset()));
-    }
-
-    [Test]
-    public void GetForecastOnDateAsync_ThrowsWhenNull()
-    {
-        this.SetupBasicHandlers("null");
-
-        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
-        client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
-        var ba = new BalancingAuthority() { Abbreviation = "balauth" };
-
-        Assert.ThrowsAsync<WattTimeClientException>(async () => await client.GetForecastOnDateAsync(ba.Abbreviation, new DateTimeOffset()));
-        Assert.ThrowsAsync<WattTimeClientException>(async () => await client.GetForecastOnDateAsync(ba, new DateTimeOffset()));
-    }
-
-    [Test]
     public async Task GetForecastOnDateAsync_DeserializesExpectedResponse()
     {
         this.AddHandlers_Auth();
@@ -321,28 +293,6 @@ public class WattTimeClientTests
         var forecast = await client.GetForecastOnDateAsync("balauth", new DateTimeOffset());
 
         Assert.AreEqual(new DateTimeOffset(2099, 1, 1, 0, 0, 0, TimeSpan.Zero), forecast!.GeneratedAt);
-    }
-
-    [Test]
-    public void GetBalancingAuthorityAsync_ThrowsWhenBadJsonIsReturned()
-    {
-        this.SetupBasicHandlers("This is bad json.");
-
-        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
-        client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
-
-        Assert.ThrowsAsync<JsonException>(async () => await client.GetBalancingAuthorityAsync("lat", "long"));
-    }
-
-    [Test]
-    public void GetBalancingAuthorityAsync_ThrowsWhenNull()
-    {
-        this.SetupBasicHandlers("null");
-
-        var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
-        client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
-
-        Assert.ThrowsAsync<WattTimeClientException>(async () => await client.GetBalancingAuthorityAsync("lat", "long"));
     }
 
     [Test]

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/Client/WattTimeClientTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/Client/WattTimeClientTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
+using Moq.Contrib.HttpClient;
 using NUnit.Framework;
 using System;
 using System.IO;
@@ -12,7 +13,6 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace CarbonAware.DataSources.WattTime.Client.Tests;
@@ -20,9 +20,7 @@ namespace CarbonAware.DataSources.WattTime.Client.Tests;
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 public class WattTimeClientTests
 {
-    private MockHttpMessageHandler MessageHandler { get; set; }
-
-    private HttpClient HttpClient { get; set; }
+    private Mock<HttpMessageHandler> Handler { get; set; }
 
     private IHttpClientFactory HttpClientFactory { get; set; }
 
@@ -49,20 +47,28 @@ public class WattTimeClientTests
         this.Options.Setup(o => o.CurrentValue).Returns(() => this.Configuration);
 
         this.BasicAuthValue = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{this.Configuration.Username}:{this.Configuration.Password}"));
+
+        this.Handler = new Mock<HttpMessageHandler>();
+        this.HttpClientFactory = Handler.CreateClientFactory();
+        Mock.Get(this.HttpClientFactory).Setup(x => x.CreateClient(IWattTimeClient.NamedClient))
+            .Returns(() =>
+            {
+                var client = Handler.CreateClient();
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", this.DefaultTokenValue);
+                return client;
+            });
+
+        this.MemoryCache = new MemoryCache(new MemoryCacheOptions());
     }
 
     [Test]
     public void AllPublicMethods_ThrowsWhenInvalidLogin()
     {
-        this.CreateHttpClient(m =>
-        {
-            var response = this.MockWattTimeAuthResponse(m, new StringContent(""), "token");
-            return Task.FromResult(response);
-        });
+        this.AddHandlers_Auth("token");
 
         this.BasicAuthValue = "invalid";
         var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
-        
+
         Assert.ThrowsAsync<WattTimeClientHttpException>(async () => await client.GetDataAsync("ba", new DateTimeOffset(), new DateTimeOffset()));
         Assert.ThrowsAsync<WattTimeClientHttpException>(async () => await client.GetCurrentForecastAsync("ba"));
         Assert.ThrowsAsync<WattTimeClientHttpException>(async () => await client.GetForecastOnDateAsync("ba", new DateTimeOffset()));
@@ -74,11 +80,7 @@ public class WattTimeClientTests
     [Test]
     public void GetDataAsync_ThrowsWhenBadJsonIsReturned()
     {
-        this.CreateHttpClient(m =>
-        {
-            var response = this.MockWattTimeAuthResponse(m, new StringContent("This is bad json."));
-            return Task.FromResult(response);
-        });
+        this.SetupBasicHandlers("This is bad json.");
 
         var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
@@ -90,13 +92,11 @@ public class WattTimeClientTests
     [Test]
     public async Task GetDataAsync_DeserializesExpectedResponse()
     {
-        this.CreateHttpClient(m =>
+        this.AddHandlers_Auth();
+        this.AddHandler_RequestResponse(r =>
         {
-            Assert.AreEqual("https://api2.watttime.org/v2/data?ba=balauth&starttime=2022-04-22T00%3a00%3a00.0000000%2b00%3a00&endtime=2022-04-22T00%3a00%3a00.0000000%2b00%3a00", m.RequestUri?.ToString());
-            Assert.AreEqual(HttpMethod.Get, m.Method);
-            var response = this.MockWattTimeAuthResponse(m, new StringContent(TestData.GetGridDataJsonString()));
-            return Task.FromResult(response);
-        });
+            return r.RequestUri!.ToString().Equals("https://api2.watttime.org/v2/data?ba=balauth&starttime=2022-04-22T00%3a00%3a00.0000000%2b00%3a00&endtime=2022-04-22T00%3a00%3a00.0000000%2b00%3a00") && r.Method == HttpMethod.Get;
+        }, System.Net.HttpStatusCode.OK, TestData.GetGridDataJsonString());
 
         var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
@@ -117,18 +117,13 @@ public class WattTimeClientTests
     [Test]
     public async Task GetDataAsync_RefreshesTokenWhenExpired()
     {
-        this.CreateHttpClient(m =>
-        {
-            var content = new StringContent(TestData.GetGridDataJsonString());
-            var response = this.MockWattTimeAuthResponse(m, content, "REFRESHTOKEN");
-            return Task.FromResult(response);
-        });
+        this.SetupBasicHandlers(TestData.GetGridDataJsonString(), "REFRESHTOKEN");
 
         var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
 
         var data = await client.GetDataAsync("balauth", new DateTimeOffset(), new DateTimeOffset());
-        
+
         Assert.IsTrue(data.Count() > 0);
         var gridDataPoint = data.ToList().First();
         Assert.AreEqual("ba", gridDataPoint.BalancingAuthorityAbbreviation);
@@ -137,12 +132,7 @@ public class WattTimeClientTests
     [Test]
     public async Task GetDataAsync_RefreshesTokenWhenNoneSet()
     {
-        this.CreateHttpClient(m =>
-        {
-            var content = new StringContent(TestData.GetGridDataJsonString());
-            var response = this.MockWattTimeAuthResponse(m, content, "REFRESHTOKEN");
-            return Task.FromResult(response);
-        });
+        this.SetupBasicHandlers(TestData.GetGridDataJsonString(), "REFRESHTOKEN");
 
         var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
 
@@ -156,16 +146,11 @@ public class WattTimeClientTests
     [Test]
     public void GetCurrentForecastAsync_ThrowsWhenBadJsonIsReturned()
     {
-        this.CreateHttpClient(m =>
-        {
-            var response = this.MockWattTimeAuthResponse(m, new StringContent("This is bad json."));
-            return Task.FromResult(response);
-        });
-
+        this.SetupBasicHandlers("This is bad json.");
 
         var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
-        var ba = new BalancingAuthority(){ Abbreviation = "balauth" };
+        var ba = new BalancingAuthority() { Abbreviation = "balauth" };
 
         Assert.ThrowsAsync<JsonException>(async () => await client.GetCurrentForecastAsync(ba.Abbreviation));
         Assert.ThrowsAsync<JsonException>(async () => await client.GetCurrentForecastAsync(ba));
@@ -174,35 +159,29 @@ public class WattTimeClientTests
     [Test]
     public void GetCurrentForecastAsync_ThrowsWhenNull()
     {
-        this.CreateHttpClient(m =>
-        {
-            var response = this.MockWattTimeAuthResponse(m, new StringContent("null"));
-            return Task.FromResult(response);
-        });
+        this.SetupBasicHandlers("null");
 
         var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
-        var ba = new BalancingAuthority(){ Abbreviation = "balauth" };
+        var ba = new BalancingAuthority() { Abbreviation = "balauth" };
 
         Assert.ThrowsAsync<WattTimeClientException>(async () => await client.GetCurrentForecastAsync(ba.Abbreviation));
-        Assert.ThrowsAsync<WattTimeClientException>(async () => await client.GetCurrentForecastAsync(ba));
+        // Assert.ThrowsAsync<WattTimeClientException>(async () => await client.GetCurrentForecastAsync(ba));
     }
 
     [Test]
     public async Task GetCurrentForecastAsync_DeserializesExpectedResponse()
     {
-        this.CreateHttpClient(m =>
+        this.AddHandlers_Auth();
+        this.AddHandler_RequestResponse(r =>
         {
-            Assert.AreEqual("https://api2.watttime.org/v2/forecast?ba=balauth", m.RequestUri?.ToString());
-            Assert.AreEqual(HttpMethod.Get, m.Method);
-            var response = this.MockWattTimeAuthResponse(m, new StringContent(TestData.GetCurrentForecastJsonString()));
-            return Task.FromResult(response);
-        });
+            return r.RequestUri!.ToString().Equals("https://api2.watttime.org/v2/forecast?ba=balauth") && r.Method == HttpMethod.Get;
+        }, System.Net.HttpStatusCode.OK, TestData.GetCurrentForecastJsonString());
 
         var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
 
-        var ba = new BalancingAuthority(){ Abbreviation = "balauth" };
+        var ba = new BalancingAuthority() { Abbreviation = "balauth" };
 
         var forecast = await client.GetCurrentForecastAsync(ba.Abbreviation);
         var overloadedForecast = await client.GetCurrentForecastAsync(ba);
@@ -222,12 +201,7 @@ public class WattTimeClientTests
     [Test]
     public async Task GetCurrentForecastAsync_RefreshesTokenWhenExpired()
     {
-        this.CreateHttpClient(m =>
-        {
-            var content = new StringContent(TestData.GetCurrentForecastJsonString());
-            var response = this.MockWattTimeAuthResponse(m, content, "REFRESHTOKEN");
-            return Task.FromResult(response);
-        });
+        this.SetupBasicHandlers(TestData.GetCurrentForecastJsonString(), "REFRESHTOKEN");
 
         var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
@@ -243,16 +217,17 @@ public class WattTimeClientTests
     [Test]
     public async Task GetCurrentForecastAsync_RefreshesTokenWhenNoneSet()
     {
-        this.CreateHttpClient(m =>
-        {
-            var content = new StringContent(TestData.GetCurrentForecastJsonString());
-            var response = this.MockWattTimeAuthResponse(m, content, "REFRESHTOKEN");
-            return Task.FromResult(response);
-        });
+        // Override http client mock to remove authorization header
+        Mock.Get(this.HttpClientFactory).Setup(x => x.CreateClient(IWattTimeClient.NamedClient))
+            .Returns(() =>
+            {
+                var client = Handler.CreateClient();
+                client.DefaultRequestHeaders.Authorization = null; // Null authorization header
+                return client;
+            });
+        this.SetupBasicHandlers(TestData.GetCurrentForecastJsonString(), "REFRESHTOKEN");
 
         var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
-
-        this.HttpClient.DefaultRequestHeaders.Authorization = null;
 
         var forecast = await client.GetCurrentForecastAsync("balauth");
 
@@ -265,15 +240,11 @@ public class WattTimeClientTests
     [Test]
     public void GetForecastOnDateAsync_ThrowsWhenBadJsonIsReturned()
     {
-        this.CreateHttpClient(m =>
-        {
-            var response = this.MockWattTimeAuthResponse(m, new StringContent("This is bad json."));
-            return Task.FromResult(response);
-        });
+        this.SetupBasicHandlers("This is bad json.");
 
         var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
-        var ba = new BalancingAuthority(){ Abbreviation = "balauth" };
+        var ba = new BalancingAuthority() { Abbreviation = "balauth" };
 
         Assert.ThrowsAsync<JsonException>(async () => await client.GetForecastOnDateAsync(ba.Abbreviation, new DateTimeOffset()));
         Assert.ThrowsAsync<JsonException>(async () => await client.GetForecastOnDateAsync(ba, new DateTimeOffset()));
@@ -282,15 +253,11 @@ public class WattTimeClientTests
     [Test]
     public void GetForecastOnDateAsync_ThrowsWhenNull()
     {
-        this.CreateHttpClient(m =>
-        {
-            var response = this.MockWattTimeAuthResponse(m, new StringContent("null"));
-            return Task.FromResult(response);
-        });
+        this.SetupBasicHandlers("null");
 
         var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
-        var ba = new BalancingAuthority(){ Abbreviation = "balauth" };
+        var ba = new BalancingAuthority() { Abbreviation = "balauth" };
 
         Assert.ThrowsAsync<WattTimeClientException>(async () => await client.GetForecastOnDateAsync(ba.Abbreviation, new DateTimeOffset()));
         Assert.ThrowsAsync<WattTimeClientException>(async () => await client.GetForecastOnDateAsync(ba, new DateTimeOffset()));
@@ -299,17 +266,15 @@ public class WattTimeClientTests
     [Test]
     public async Task GetForecastOnDateAsync_DeserializesExpectedResponse()
     {
-        this.CreateHttpClient(m =>
+        this.AddHandlers_Auth();
+        this.AddHandler_RequestResponse(r =>
         {
-            Assert.AreEqual("https://api2.watttime.org/v2/forecast?ba=balauth&starttime=2022-04-22T00%3a00%3a00.0000000%2b00%3a00&endtime=2022-04-22T00%3a00%3a00.0000000%2b00%3a00", m.RequestUri?.ToString());
-            Assert.AreEqual(HttpMethod.Get, m.Method);
-            var response = this.MockWattTimeAuthResponse(m, new StringContent(TestData.GetForecastByDateJsonString()));
-            return Task.FromResult(response);
-        });
+            return r.RequestUri!.ToString().Equals("https://api2.watttime.org/v2/forecast?ba=balauth&starttime=2022-04-22T00%3a00%3a00.0000000%2b00%3a00&endtime=2022-04-22T00%3a00%3a00.0000000%2b00%3a00") && r.Method == HttpMethod.Get;
+        }, System.Net.HttpStatusCode.OK, TestData.GetForecastByDateJsonString());
 
         var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
-        var ba = new BalancingAuthority(){ Abbreviation = "balauth" };
+        var ba = new BalancingAuthority() { Abbreviation = "balauth" };
 
         var forecast = await client.GetForecastOnDateAsync(ba.Abbreviation, new DateTimeOffset(2022, 4, 22, 0, 0, 0, TimeSpan.Zero));
         var overloadedForecast = await client.GetForecastOnDateAsync(ba, new DateTimeOffset(2022, 4, 22, 0, 0, 0, TimeSpan.Zero));
@@ -328,12 +293,7 @@ public class WattTimeClientTests
     [Test]
     public async Task GetForecastOnDateAsync_RefreshesTokenWhenExpired()
     {
-        this.CreateHttpClient(m =>
-        {
-            var content = new StringContent(TestData.GetForecastByDateJsonString());
-            var response = this.MockWattTimeAuthResponse(m, content, "REFRESHTOKEN");
-            return Task.FromResult(response);
-        });
+        this.SetupBasicHandlers(TestData.GetForecastByDateJsonString(), "REFRESHTOKEN");
 
         var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
@@ -345,30 +305,28 @@ public class WattTimeClientTests
     [Test]
     public async Task GetForecastOnDateAsync_RefreshesTokenWhenNoneSet()
     {
-        this.CreateHttpClient(m =>
-        {
-            var content = new StringContent(TestData.GetForecastByDateJsonString());
-            var response = this.MockWattTimeAuthResponse(m, content, "REFRESHTOKEN");
-            return Task.FromResult(response);
-        });
+        // Override http client mock to remove authorization header
+        Mock.Get(this.HttpClientFactory).Setup(x => x.CreateClient(IWattTimeClient.NamedClient))
+            .Returns(() =>
+            {
+                var client = Handler.CreateClient();
+                client.DefaultRequestHeaders.Authorization = null; // Null authorization header
+                return client;
+            });
+
+        this.SetupBasicHandlers(TestData.GetForecastByDateJsonString(), "REFRESHTOKEN");
 
         var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
 
-        this.HttpClient.DefaultRequestHeaders.Authorization = null;
-
         var forecast = await client.GetForecastOnDateAsync("balauth", new DateTimeOffset());
-        
+
         Assert.AreEqual(new DateTimeOffset(2099, 1, 1, 0, 0, 0, TimeSpan.Zero), forecast!.GeneratedAt);
     }
 
     [Test]
     public void GetBalancingAuthorityAsync_ThrowsWhenBadJsonIsReturned()
     {
-        this.CreateHttpClient(m =>
-        {
-            var response = this.MockWattTimeAuthResponse(m, new StringContent("This is bad json."));
-            return Task.FromResult(response);
-        });
+        this.SetupBasicHandlers("This is bad json.");
 
         var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
@@ -379,11 +337,7 @@ public class WattTimeClientTests
     [Test]
     public void GetBalancingAuthorityAsync_ThrowsWhenNull()
     {
-        this.CreateHttpClient(m =>
-        {
-            var response = this.MockWattTimeAuthResponse(m, new StringContent("null"));
-            return Task.FromResult(response);
-        });
+        this.SetupBasicHandlers("null");
 
         var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
@@ -394,13 +348,11 @@ public class WattTimeClientTests
     [Test]
     public async Task GetBalancingAuthorityAsync_DeserializesExpectedResponse()
     {
-        this.CreateHttpClient(m =>
+        this.AddHandlers_Auth();
+        this.AddHandler_RequestResponse(r =>
         {
-            Assert.AreEqual("https://api2.watttime.org/v2/ba-from-loc?latitude=lat&longitude=long", m.RequestUri?.ToString());
-            Assert.AreEqual(HttpMethod.Get, m.Method);
-            var response = this.MockWattTimeAuthResponse(m, new StringContent(TestData.GetBalancingAuthorityJsonString()));
-            return Task.FromResult(response);
-        });
+            return r.RequestUri!.ToString().Equals("https://api2.watttime.org/v2/ba-from-loc?latitude=lat&longitude=long") && r.Method == HttpMethod.Get;
+        }, System.Net.HttpStatusCode.OK, TestData.GetBalancingAuthorityJsonString());
 
         var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
@@ -416,12 +368,7 @@ public class WattTimeClientTests
     [Test]
     public async Task GetBalancingAuthorityAsync_RefreshesTokenWhenExpired()
     {
-        this.CreateHttpClient(m =>
-        {
-            var content = new StringContent(TestData.GetBalancingAuthorityJsonString());
-            var response = this.MockWattTimeAuthResponse(m, content, "REFRESHTOKEN");
-            return Task.FromResult(response);
-        });
+        this.SetupBasicHandlers(TestData.GetBalancingAuthorityJsonString(), "REFRESHTOKEN");
 
         var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
         client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
@@ -435,16 +382,18 @@ public class WattTimeClientTests
     [Test]
     public async Task GetBalancingAuthorityAsync_RefreshesTokenWhenNoneSet()
     {
-        this.CreateHttpClient(m =>
-        {
-            var content = new StringContent(TestData.GetBalancingAuthorityJsonString());
-            var response = this.MockWattTimeAuthResponse(m, content, "REFRESHTOKEN");
-            return Task.FromResult(response);
-        });
+        // Override http client mock to remove authorization header
+        Mock.Get(this.HttpClientFactory).Setup(x => x.CreateClient(IWattTimeClient.NamedClient))
+            .Returns(() =>
+            {
+                var client = Handler.CreateClient();
+                client.DefaultRequestHeaders.Authorization = null; // Null authorization header
+                return client;
+            });
+
+        this.SetupBasicHandlers(TestData.GetBalancingAuthorityJsonString(), "REFRESHTOKEN");
 
         var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
-
-        this.HttpClient.DefaultRequestHeaders.Authorization = null;
 
         var ba = await client.GetBalancingAuthorityAsync("lat", "long");
 
@@ -457,11 +406,7 @@ public class WattTimeClientTests
     {
         using (var testStream = new MemoryStream(Encoding.UTF8.GetBytes("myStreamResults")))
         {
-            this.CreateHttpClient(m =>
-            {
-                var response = this.MockWattTimeAuthResponse(m, new StreamContent(testStream));
-                return Task.FromResult(response);
-            });
+            this.SetupBasicHandlers(new StreamContent(testStream));
 
             var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
             client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
@@ -479,13 +424,18 @@ public class WattTimeClientTests
     {
         using (var testStream = new MemoryStream(Encoding.UTF8.GetBytes("myStreamResults")))
         {
-            this.CreateHttpClient(m =>
-            {
-                var response = this.MockWattTimeAuthResponse(m, new StreamContent(testStream), "REFRESHTOKEN");
-                return Task.FromResult(response);
-            });
+            // Override http client mock to remove authorization header
+            Mock.Get(this.HttpClientFactory).Setup(x => x.CreateClient(IWattTimeClient.NamedClient))
+                .Returns(() =>
+                {
+                    var client = Handler.CreateClient();
+                    client.DefaultRequestHeaders.Authorization = null; // Null authorization header
+                    return client;
+                });
 
-            this.HttpClient.DefaultRequestHeaders.Authorization = null;
+            this.SetupBasicHandlers(new StreamContent(testStream), "REFRESHTOKEN");
+
+
             var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
 
             var result = await client.GetHistoricalDataAsync("ba");
@@ -501,11 +451,7 @@ public class WattTimeClientTests
     {
         using (var testStream = new MemoryStream(Encoding.UTF8.GetBytes("myStreamResults")))
         {
-            this.CreateHttpClient(m =>
-            {
-                var response = this.MockWattTimeAuthResponse(m, new StreamContent(testStream), "REFRESHTOKEN");
-                return Task.FromResult(response);
-            });
+            this.SetupBasicHandlers(new StreamContent(testStream), "REFRESHTOKEN");
 
             var client = new WattTimeClient(this.HttpClientFactory, this.Options.Object, this.Log.Object, this.MemoryCache);
             client.SetBearerAuthenticationHeader(this.DefaultTokenValue);
@@ -518,58 +464,75 @@ public class WattTimeClientTests
         }
     }
 
-    private void CreateHttpClient(Func<HttpRequestMessage, Task<HttpResponseMessage>> requestDelegate)
+    /**
+    * Helper to add client handlers for auth checking
+    */
+    private void AddHandlers_Auth(string? validToken = null)
     {
-        this.MessageHandler = new MockHttpMessageHandler(requestDelegate);
-        this.HttpClient = new HttpClient(this.MessageHandler);
-        this.HttpClientFactory = Mock.Of<IHttpClientFactory>();
-        Mock.Get(this.HttpClientFactory).Setup(h => h.CreateClient(IWattTimeClient.NamedClient)).Returns(this.HttpClient);
-        this.HttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", this.DefaultTokenValue);
-        this.MemoryCache = new MemoryCache(new MemoryCacheOptions());
+        validToken ??= this.DefaultTokenValue;
+
+        AddHandler_RequestResponse(r =>
+        {
+            return r.Headers.Authorization == null;
+        }, System.Net.HttpStatusCode.Unauthorized);
+
+        AddHandler_RequestResponse(r =>
+        {
+            return (r.RequestUri == new Uri("https://api2.watttime.org/v2/login") && ($"Basic {this.BasicAuthValue}".Equals(r.Headers.Authorization?.ToString())));
+        }, System.Net.HttpStatusCode.OK, "{\"token\":\"" + validToken + "\"}");
+
+        AddHandler_RequestResponse(r =>
+        {
+            return !(r.RequestUri == new Uri("https://api2.watttime.org/v2/login") && ($"Basic {this.BasicAuthValue}".Equals(r.Headers.Authorization?.ToString()))) && r.Headers.Authorization?.ToString() != $"Bearer {validToken}";
+        }, System.Net.HttpStatusCode.Forbidden);
     }
 
-    private HttpResponseMessage MockWattTimeAuthResponse(HttpRequestMessage request, HttpContent reponseContent, string? validToken = null)
+    /**
+    * Helper to add client handlers for auth and basic content return
+    */
+    private void SetupBasicHandlers(StreamContent responseContent, string? validToken = null)
     {
-        if (validToken == null)
-        {
-            validToken = this.DefaultTokenValue;
-        }
-        var auth = this.HttpClient.DefaultRequestHeaders.Authorization;
-        if (auth == null)
-        {
-            return new HttpResponseMessage(System.Net.HttpStatusCode.Unauthorized);
-        }
+        validToken ??= this.DefaultTokenValue;
 
-        var authHeader = auth.ToString();
-        var response = new HttpResponseMessage(System.Net.HttpStatusCode.OK);
+        AddHandlers_Auth(validToken);
 
-        if ((request.RequestUri == new Uri("https://api2.watttime.org/v2/login") && ($"Basic {this.BasicAuthValue}".Equals(authHeader))))
+        // Catch-all for "requesting url that is not login and has valid token"
+        this.Handler
+            .SetupRequest(r => r.RequestUri != new Uri("https://api2.watttime.org/v2/login") && r.Headers.Authorization?.ToString() == $"Bearer {validToken}")
+            .ReturnsResponse(System.Net.HttpStatusCode.OK, responseContent);
+    }
+
+    /**
+    * Helper to add client handlers for auth and basic content return
+    */
+    private void SetupBasicHandlers(string responseContent, string? validToken = null)
+    {
+        validToken ??= this.DefaultTokenValue;
+
+        AddHandlers_Auth(validToken);
+
+        // Catch-all for "requesting url that is not login and has valid token"
+        AddHandler_RequestResponse(r => r.RequestUri != new Uri("https://api2.watttime.org/v2/login") && r.Headers.Authorization?.ToString() == $"Bearer {validToken}", System.Net.HttpStatusCode.OK, responseContent);
+    }
+
+    /**
+     * Helper to add client handler for request predicate and corresponding status code and response content
+     */
+    private void AddHandler_RequestResponse(Predicate<HttpRequestMessage> requestPredicate, System.Net.HttpStatusCode statusCode, string? responseContent = null)
+    {
+        if (responseContent != null)
         {
-            response.Content = new StringContent("{\"token\":\""+validToken+"\"}");
-        }
-        else if (authHeader == $"Bearer {validToken}")
-        {
-            response.Content = reponseContent;
+            this.Handler
+                .SetupRequest(requestPredicate)
+                .ReturnsResponse(statusCode, responseContent);
         }
         else
         {
-            response.StatusCode = System.Net.HttpStatusCode.Forbidden;
-        }
-        return response;
-    }
-
-    private class MockHttpMessageHandler : HttpMessageHandler
-    {
-        private Func<HttpRequestMessage, Task<HttpResponseMessage>> RequestDelegate { get; set; }
-
-        public MockHttpMessageHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> requestDelegate)
-        {
-            this.RequestDelegate = requestDelegate;
-        }
-        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            return await this.RequestDelegate.Invoke(request);
+            this.Handler
+                .SetupRequest(requestPredicate)
+                .ReturnsResponse(statusCode);
         }
     }
 }
+
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.


### PR DESCRIPTION
Issue Number: #240 

## Summary
Updating external client tests (ElectricityMapsClient and WattTimeClient) to use Moq infrastrucutre for HTTP requests

## Changes

- Updated `ElectricityMapsClientTests.test.cs` and `WattTimeClientTests.test.cs` files to use Moq for Http client instead of custom class

## Checklist

- [X] Local Tests Passing?
- [ ] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [ ] This is not a breaking change. If it is, please describe it below.

This PR Closes #240 
