### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/agenda-template.md
+++ b/.github/ISSUE_TEMPLATE/agenda-template.md
@@ -1,0 +1,50 @@
+---
+name: agenda-template
+about: Agenda issue template for weekly Carbon Aware SDK community calls
+title: "\U0001F3AF"
+labels: Agenda
+assignees: ''
+
+---
+
+## Date
+YYYY-MM-DD - 8am UTC
+
+## Meeting notices
+
+### Antitrust Policy
+Linux Foundation meetings involve participation by industry competitors, and it is the intention of the Linux Foundation to conduct all of its activities in accordance with applicable antitrust and competition laws. It is therefore extremely important that attendees adhere to meeting agendas, and be aware of, and not participate in, any activities that are prohibited under applicable US state, federal or foreign antitrust and competition laws.
+
+Examples of types of actions that are prohibited at Linux Foundation meetings and in connection with Linux Foundation activities are described in the Linux Foundation Antitrust Policy available at http://www.linuxfoundation.org/antitrust-policy. If you have questions about these matters, please contact your company counsel, or if you are a member of the Linux Foundation, feel free to contact Andrew Updegrove of the firm of Gesmer Updegrove LLP, which provides legal counsel to the Linux Foundation.
+
+### Recordings
+GSF project meetings may be recorded for use solely by the GSF team for administration purposes. In very limited instances, and with explicit approval, recordings may be made more widely available.
+
+### Roll Call 
+Please *add a comment* to this issue during the meeting to denote attendance.
+
+| Full Name | Affiliation | GitHub username (optional) |
+|---|---|---|
+|Vaughan Knight | Microsoft |  [vaughanknight](https://github.com/vaughanknight) | 
+
+Any untracked attendees will be added by the GSF team below
+
+## Agenda
+- [ ] Convene & Roll Call (5mins)
+- [ ] Review Meeting Notices (see above)
+- [ ] Review the agenda and suggest new agenda points
+- [ ] Approve Past Meeting Minutes
+- [ ] Review Pull Requests
+- [ ] Discuss Issues
+
+# PRs
+
+# Issues 
+
+## Discussion 
+- [ ]  
+
+## Action Items
+- [ ] 
+
+**Meeting attended by**


### PR DESCRIPTION
Issue Number: Outcome of the meeting: #248 

## Summary
Added an Agenda Template for the weekly Carbon Aware SDK meetings. Example such issue can be found on my fork: https://github.com/Willmish/carbon-aware-sdk/issues/3

## Changes

- Modifies the `.github/ISSUE_TEMPLATE` folder and adds a new `agenda-template.yml` file

## Checklist

- [x] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [x] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?
None

## Is this a breaking change?
N/A

## Anything else?
Other comments, collaborators, etc.
> Please follow [GitHub's suggested syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) to link Pull Requests to Issues via keywords

