### PR TITLE
Add docs + error checking to improve experience for free trial ElectricityMaps Users

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -247,7 +247,10 @@ required.
 ```
 
 > **Sign up for a free trial:** Select the free trial product from
-> [the ElectricityMaps catalog](https://api-portal.electricitymaps.com/)
+> [the ElectricityMaps catalog](https://api-portal.electricitymaps.com/). Note
+> that there are some
+> [restrictions](./selecting-a-data-source.md#restrictions-electricitymaps-free-trial-user)
+> on the free trial product.
 
 #### API Token Header
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,10 +1,10 @@
 # Overview
 
-There are several ways to consume CarbonAware data for your use case.
-Each approach surfaces the same data for the same call (e.g. the CLI
-should not give you different data than the WebAPI for the same query).
-We provide a number of different endpoints to provide the most flexibility
-to integrate to your environment:
+There are several ways to consume CarbonAware data for your use case. Each
+approach surfaces the same data for the same call (e.g. the CLI should not give
+you different data than the WebAPI for the same query). We provide a number of
+different endpoints to provide the most flexibility to integrate to your
+environment:
 
 - You can run the application using the [CLI](./src/CarbonAware.CLI) and refer
   to more documentation [here](./carbon-aware-cli.md).
@@ -13,17 +13,17 @@ to integrate to your environment:
   and connect via REST requests and refer to more documentation
   [here](./carbon-aware-webapi.md).
 
-- You can reference the [Carbon Aware C# Library](./src/GSF.CarbonAware)
-  in your projects and make use of its functionalities and features.
+- You can reference the [Carbon Aware C# Library](./src/GSF.CarbonAware) in your
+  projects and make use of its functionalities and features.
 
 - (Future) You can install the Nuget package and make requests directly.
   ([tracked here](https://github.com/Green-Software-Foundation/carbon-aware-sdk/issues/40))
 
-Each of these has configuration requirements which are detailed below.
-You can also visit the [quickstart.md](docs/quickstart.md) guide for a step-by-step
-process for running the CLI locally, deploying the Web API locally or in the cloud,
-polling the API via HTTP requests or generating and using
-client libraries (Python example).
+Each of these has configuration requirements which are detailed below. You can
+also visit the [quickstart.md](docs/quickstart.md) guide for a step-by-step
+process for running the CLI locally, deploying the Web API locally or in the
+cloud, polling the API via HTTP requests or generating and using client
+libraries (Python example).
 
 For more detailed architecture and design decisions around the Carbon Aware SDK,
 refer to the [Architecture directory](./architecture/).
@@ -31,47 +31,50 @@ refer to the [Architecture directory](./architecture/).
 ## Carbon Aware Library
 
 The Carbon Aware SDK provides a C# Client Library with handlers that replicates
-the Web API, CLI and SDK functionality, leveraging the same configurations as the
-aggregators. See:
+the Web API, CLI and SDK functionality, leveraging the same configurations as
+the aggregators. See:
 
-- [carbon-aware-library.md](./carbon-aware-library.md) for more information about
-  library features.
-- [packaging.md](./packaging.md) for details on how to package and consume
-  the library.
+- [carbon-aware-library.md](./carbon-aware-library.md) for more information
+  about library features.
+- [packaging.md](./packaging.md) for details on how to package and consume the
+  library.
 - [gsf-carbon-aware-library-package.md](./gsf-carbon-aware-library-package.md)
-  for instructions on integrating the library in other
-  projects with dependency injection.
+  for instructions on integrating the library in other projects with dependency
+  injection.
 
 ## Pre-requisites
 
-Make sure you have installed the following pre-requisites
-to setup your local environment:
+Make sure you have installed the following pre-requisites to setup your local
+environment:
 
 - dotnet core SDK
   [https://dotnet.microsoft.com/en-us/download](https://dotnet.microsoft.com/en-us/download)
 - Access to one (or all) of the supported external data APIs
   - WattTime account - See
-  [instruction on WattTime](https://www.watttime.org/api-documentation/#register-new-user)
-  for details (or use our python samples as described
-  [here](samples/watttime-registration/readme.md)).
+    [instruction on WattTime](https://www.watttime.org/api-documentation/#register-new-user)
+    for details (or use our python samples as described
+    [here](samples/watttime-registration/readme.md)).
   - ElectricityMaps account - See
-  [instruction on ElectricityMaps](https://api-portal.electricitymaps.com/home)
-  for details (or setup a [free trial](https://api-portal.electricitymaps.com)).
+    [instruction on ElectricityMaps](https://api-portal.electricitymaps.com/home)
+    for details (or setup a
+    [free trial](https://api-portal.electricitymaps.com)). Note that the free
+    trial has some
+    [restrictions](./docs/selecting-a-data-source.md#restrictions-electricitymaps-free-trial-user)
 
-Alternatively, you can also set up your environment using
-VSCode Remote Containers (Dev Container):
+Alternatively, you can also set up your environment using VSCode Remote
+Containers (Dev Container):
 
 - Docker
 - VSCode (it is recommended to work in a Dev Container)
-- [Remote Containers extension for VSCode](<https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers>)
+- [Remote Containers extension for VSCode](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
 
 ## Data Sources
 
-We support multiple data sources for carbon data. At this time,
-a JSON file, [WattTime](https://www.watttime.org/), and
-[ElectricityMaps](https://www.electricitymaps.com/) are supported.
-To use WattTime data or Electricity Maps data, you'll need to acquire a license
-from them and set the appropriate configuration information.
+We support multiple data sources for carbon data. At this time, a JSON file,
+[WattTime](https://www.watttime.org/), and
+[ElectricityMaps](https://www.electricitymaps.com/) are supported. To use
+WattTime data or Electricity Maps data, you'll need to acquire a license from
+them and set the appropriate configuration information.
 
 You can also visit the
 [selecting-a-date-source.md](docs/../selecting-a-data-source.md) guide for more
@@ -84,8 +87,8 @@ decisions around integrating different data providers into the carbon aware SDK.
 This project uses the dotnet standard
 [Microsoft.Extensions.Configuration](https://docs.microsoft.com/en-us/dotnet/core/extensions/configuration)
 mechanism, which allows the user to configure their environment variables in a
-unified view while making use of different configuration sources.
-Review the link to understand more about the `IConfiguration` type.
+unified view while making use of different configuration sources. Review the
+link to understand more about the `IConfiguration` type.
 
 The WebAPI project uses standard configuration sources provided by
 [ASPNetCore](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/).
@@ -106,8 +109,8 @@ configure specific components of the application.
 #### Environment variables
 
 When adding values via environment variables, we recommend that you use the
-double underscore form, rather than the colon form.
-Colons won't work in non-windows environment. For example:
+double underscore form, rather than the colon form. Colons won't work in
+non-windows environment. For example:
 
 ```bash
   DataSources__EmissionsDataSource="WattTime"
@@ -125,21 +128,21 @@ using environment variables, you'd do this:
 
 For local-only settings you can use environment variables,
 [the Secret Manager tool](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-6.0&tabs=windows#secret-manager)
-, or an untracked Development appsettings file to override
-the default project settings.
+, or an untracked Development appsettings file to override the default project
+settings.
 
 To use the settings file, rename a copy of the template called
 `appsettings.Development.json.template` to `appsettings.Development.json` and
-remove the first line of (invalid) comments.
-Then update any settings according to your preferences.
+remove the first line of (invalid) comments. Then update any settings according
+to your preferences.
 
 > Wherever possible, the projects leverage the
 > [default .NET configuration](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-6.0#default-application-configuration-sources)
-> expectations. Thus, they can be configured using any file matching the
-> format: `appsettings.<ENV>.json`. Where `<ENV>` is the value of
-> the `ASPNETCORE_ENVIRONMENT` environment variable. By convention projects
-> tend to use the provided HostEnvironment constants
-> `Development`, `Staging`, and `Production`.
+> expectations. Thus, they can be configured using any file matching the format:
+> `appsettings.<ENV>.json`. Where `<ENV>` is the value of the
+> `ASPNETCORE_ENVIRONMENT` environment variable. By convention projects tend to
+> use the provided HostEnvironment constants `Development`, `Staging`, and
+> `Production`.
 
 ## Publish WebAPI with container
 
@@ -158,8 +161,8 @@ $podman build -t carbon-aware-sdk-webapi -f CarbonAware.WebApi/src/Dockerfile .
 
 ### Run Web API container
 
-Carbon Aware SDK Web API publishes the service on Port 80, so you need to map
-it to local port. Following commands maps it to Port 8080.
+Carbon Aware SDK Web API publishes the service on Port 80, so you need to map it
+to local port. Following commands maps it to Port 8080.
 
 You also need to configure the SDK with environment variables. They are minimum
 set when you use WattTime or ElectricityMaps as a data source.
@@ -200,5 +203,5 @@ $ curl -s http://localhost:8080/emissions/forecasts/current?location=westus2 | j
             :
 ```
 
-For more information on containerization, refer to the
-markdown in [containerization.md](./containerization.md).
+For more information on containerization, refer to the markdown in
+[containerization.md](./containerization.md).

--- a/docs/selecting-a-data-source.md
+++ b/docs/selecting-a-data-source.md
@@ -10,20 +10,21 @@ enabled for which data sources.
 - [Type of Data Sources and Configuration](#type-of-data-sources-and-configuration)
 - [Data Source Methods Available](#data-source-methods-available)
 - [Location Coverage](#location-coverage)
+- [Restriction: ElectricityMaps Free Trial User](#restrictions-electricitymaps-free-trial-user)
 
 ## Type of Data Sources and Configuration
 
 In the CarbonAware SDK configuration, you can set what data source to use as the
 `EmissionsDataSource` and the `ForecastDataSource`. There are also certain
-configuration fields that must be set in order to access the raw data. | Type |
-WattTime | ElectricityMaps | JSON |
-|---|---|---|---| | Is Emissions
-DataSource | &#9989; | &#9989; | &#9989; | | Is Forecast DataSource | &#9989; |
-&#9989; | &#10060; | | Makes HTTP(s) call | &#9989; | &#9989; | &#10060; | | Can
-Use Custom Data | &#10060; | &#10060; | &#9989; | | Supports Trial + Full
-Account | &#9989; | &#9989;
-(\*[different config required](./configuration.md#electricitymaps-configuration))
-| N/A |
+configuration fields that must be set in order to access the raw data.
+
+| Type | WattTime  | ElectricityMaps | JSON |
+|------|------|------|------|
+| Is Emissions DataSource | &#9989; | &#9989; | &#9989; |
+| Is Forecast DataSource | &#9989;  | &#9989; | &#10060; |
+| Makes HTTP(s) call | &#9989;  | &#9989; | &#10060; |
+| Can Use Custom Data | &#10060;  | &#10060; | &#9989; |
+| Supports Trial + Full Account | &#9989;  | &#9989; (*[see restriction below](#restrictions-electricitymaps-free-trial-user)) | N/A |
 
 ## Data Source Methods Available
 
@@ -44,8 +45,44 @@ data source may have different region names, which are handled through the
 location config.
 
 - For `WattTime`, see their
- [interactive coverage map](https://www.watttime.org/explorer) to find the
- relevant zone.
+  [interactive coverage map](https://www.watttime.org/explorer) to find the
+  relevant zone.
 - For `ElectricityMaps`, see their
- [live map app](https://app.electricitymaps.com/map?utm_source=electricitymaps.com&utm_medium=website&utm_campaign=banner)
- to find the relevant zone and see current data coming in.
+  [live map app](https://app.electricitymaps.com/map?utm_source=electricitymaps.com&utm_medium=website&utm_campaign=banner)
+  to find the relevant zone and see current data coming in.
+
+## Restrictions: ElectricityMaps Free Trial User
+
+ElectricityMaps allows new users to create a free trial for 1 month access to
+the API. Free trial users have restricted access to the API and a slightly
+different configuration for the SDK (see
+[configuration.md](./configuration.md#electricitymaps-configuration). You can
+request a free trial on the
+[ElectricityMaps API Portal](https://api-portal.electricitymaps.com/).
+
+### Restricted Zone Access
+
+Free trial users only have access ~100 zones in the ElectricityMaps API.
+ElectricityMaps maintains a
+[frequently updated list](https://docs.google.com/document/d/e/2PACX-1vTdYp8E5E3fNogL54ICf_UxfA_rZ_RPO4WKWI4ZANPSX25jCbvHtAxc-VrJt9HymeRHFcSGWXjhVHS0/pub)
+of available free trial zones that include the key, name, and country of each
+zone. If you need access to other zones not included on the list, you will need
+a full access product key.
+
+### Restricted Endpoint Access
+
+Free trial users only have access to seven endpoints in the ElectricityMaps API.
+Of those seven, only two are currently supported as part of Carbon Aware SDK:
+
+1. `GET /carbon-intensity/forecast`
+2. `GET /carbon-intensity/history`
+
+> Note: The Carbon Aware SDK is not restricting implementations to only support
+> free trial users of ElectricityMaps. There may be implementations in the
+> future that use endpoints that a free trial user may not be able to access and
+> therefore cannot use that functionality of the SDK.
+
+### Restricted Call Access
+
+Free trial users are capped at 1,000 calls for the month of the free trial. Any
+calls beyond the 1,000th call will be rejected.

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMaps/src/Configuration/ElectricityMapsClientConfiguration.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMaps/src/Configuration/ElectricityMapsClientConfiguration.cs
@@ -54,5 +54,14 @@ public class ElectricityMapsClientConfiguration
         if (string.IsNullOrWhiteSpace(this.APITokenHeader) || string.IsNullOrWhiteSpace(this.APIToken)){
             throw new ConfigurationException($"Incomplete auth config: must set both {nameof(this.APITokenHeader)} and {nameof(this.APIToken)}.");
         }
+
+        // Required to have correct token header given base url
+        if (BaseUrl.Equals(BaseUrls.TokenBaseUrl) && !APITokenHeader.Equals(Headers.TokenAuthHeader)){
+            throw new ConfigurationException($"Invalid configuration. {nameof(this.BaseUrl)} '{this.BaseUrl}' requires '{Headers.TokenAuthHeader}' as the {nameof(this.APITokenHeader)}.");
+        }
+
+        if (BaseUrl.Equals(BaseUrls.TrialBaseUrl) && !APITokenHeader.Equals(Headers.TrialAuthHeader)){
+            throw new ConfigurationException($"Invalid configuration. {nameof(this.BaseUrl)} '{this.BaseUrl}' requires '{Headers.TrialAuthHeader}' as the {nameof(this.APITokenHeader)}.");
+        }
     }
 }

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMaps/src/Constants/ErrorMessages.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMaps/src/Constants/ErrorMessages.cs
@@ -1,0 +1,9 @@
+
+namespace CarbonAware.DataSources.ElectricityMaps.Constants;
+
+internal class ErrorMessages
+{
+    public const string UnauthorizedZone = "Token unauthorized for zoneKey";
+
+    public const string UnauthorizedEndpoint = "Endpoint not available";
+}

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMaps/src/Constants/Headers.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMaps/src/Constants/Headers.cs
@@ -1,0 +1,6 @@
+namespace CarbonAware.DataSources.ElectricityMaps.Constants;
+
+internal class Headers {
+    public const string TokenAuthHeader = "auth-token";
+    public const string TrialAuthHeader = "X-BLOBR-KEY";
+}

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMaps/test/Client/ElectricityMapsClientTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMaps/test/Client/ElectricityMapsClientTests.cs
@@ -1,7 +1,6 @@
 using CarbonAware.DataSources.ElectricityMaps.Client;
 using CarbonAware.DataSources.ElectricityMaps.Configuration;
 using CarbonAware.DataSources.ElectricityMaps.Constants;
-using CarbonAware.DataSources.ElectricityMaps.Model;
 using CarbonAware.Exceptions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -68,13 +67,14 @@ public class ElectricityMapsClientTests
         Assert.Throws<ConfigurationException>(() => new ElectricityMapsClient(this.HttpClientFactory, this.Options.Object, this.Log.Object));
     }
 
-    [TestCase(BaseUrls.TrialBaseUrl, TestName = "ClientInstantiation_SucceedsForValidConfig: Trial")]
-    [TestCase(BaseUrls.TokenBaseUrl, TestName = "ClientInstantiation_SucceedsForValidConfig: Token")]
-    public void ClientInstantiation_SucceedsForValidConfig(string baseUrl)
+    [TestCase(BaseUrls.TrialBaseUrl, Headers.TrialAuthHeader, TestName = "ClientInstantiation_SucceedsForValidConfig: Trial")]
+    [TestCase(BaseUrls.TokenBaseUrl, Headers.TokenAuthHeader, TestName = "ClientInstantiation_SucceedsForValidConfig: Token")]
+    public void ClientInstantiation_SucceedsForValidConfig(string baseUrl, string header)
     {
         // Arrange
         AddHandlers_Auth_Zones(TestData.GetZonesAllowedJsonString());
         this.Configuration.BaseUrl = baseUrl;
+        this.Configuration.APITokenHeader = header;
 
         // Act & Assert
         Assert.DoesNotThrow(() => new ElectricityMapsClient(this.HttpClientFactory, this.Options.Object, this.Log.Object));
@@ -176,16 +176,17 @@ public class ElectricityMapsClientTests
     }
 
 
-    [TestCase(BaseUrls.TrialBaseUrl, TestName = "GetForecastedCarbonIntensityAsync_DeserializesExpectedResponse: Trial")]
-    [TestCase(BaseUrls.TokenBaseUrl, TestName = "GetForecastedCarbonIntensityAsync_DeserializesExpectedResponse: Token")]
-    public async Task GetForecastedCarbonIntensityAsync_DeserializesExpectedResponse(string baseUrl)
+    [TestCase(BaseUrls.TrialBaseUrl, Headers.TrialAuthHeader, TestName = "GetForecastedCarbonIntensityAsync_DeserializesExpectedResponse: Trial")]
+    [TestCase(BaseUrls.TokenBaseUrl, Headers.TokenAuthHeader, TestName = "GetForecastedCarbonIntensityAsync_DeserializesExpectedResponse: Token")]
+    public async Task GetForecastedCarbonIntensityAsync_DeserializesExpectedResponse(string baseUrl, string header)
     {
         // Arrange
         this.Configuration.BaseUrl = baseUrl;
+        this.Configuration.APITokenHeader = header;
         AddHandlers_Auth_Zones(TestData.GetZonesAllowedJsonString());
         AddHandler_RequestResponse(r =>
-            {
-                return r.RequestUri!.ToString().Contains(baseUrl + Paths.Forecast) && r.Method == HttpMethod.Get;
+        {
+            return r.RequestUri!.ToString().Contains(baseUrl + Paths.Forecast) && r.Method == HttpMethod.Get;
             }, System.Net.HttpStatusCode.OK, TestData.GetCurrentForecastJsonString());
 
         var client = new ElectricityMapsClient(this.HttpClientFactory, this.Options.Object, this.Log.Object);
@@ -224,12 +225,13 @@ public class ElectricityMapsClientTests
         Assert.ThrowsAsync<ElectricityMapsClientException>(async () => await client.GetRecentCarbonIntensityHistoryAsync(TestZone));
     }
 
-    [TestCase(BaseUrls.TrialBaseUrl, TestName = "GetRecentCarbonIntensityHistoryAsync_DeserializesExpectedResponse: Trial")]
-    [TestCase(BaseUrls.TokenBaseUrl, TestName = "GetRecentCarbonIntensityHistoryAsync_DeserializesExpectedResponse: Token")]
-    public async Task GetRecentCarbonIntensityHistoryAsync_DeserializesExpectedResponse(string baseUrl)
+    [TestCase(BaseUrls.TrialBaseUrl, Headers.TrialAuthHeader, TestName = "GetRecentCarbonIntensityHistoryAsync_DeserializesExpectedResponse: Trial")]
+    [TestCase(BaseUrls.TokenBaseUrl, Headers.TokenAuthHeader, TestName = "GetRecentCarbonIntensityHistoryAsync_DeserializesExpectedResponse: Token")]
+    public async Task GetRecentCarbonIntensityHistoryAsync_DeserializesExpectedResponse(string baseUrl, string header)
     {
         // Arrange
         this.Configuration.BaseUrl = baseUrl;
+        this.Configuration.APITokenHeader = header;
 
         AddHandlers_Auth_Zones(TestData.GetZonesAllowedJsonString());
         AddHandler_RequestResponse(r =>

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMaps/test/Configuration/ElectricityMapsClientConfigurationTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMaps/test/Configuration/ElectricityMapsClientConfigurationTests.cs
@@ -1,4 +1,5 @@
 using CarbonAware.DataSources.ElectricityMaps.Configuration;
+using CarbonAware.DataSources.ElectricityMaps.Constants;
 using CarbonAware.Exceptions;
 
 namespace CarbonAware.DataSources.ElectricityMaps.Tests;
@@ -7,6 +8,8 @@ namespace CarbonAware.DataSources.ElectricityMaps.Tests;
 public class ElectricityMapsClientConfigurationTests
 {
     [TestCase("x-token-header", "faketoken", "http://example.com", TestName = "Validate does not throw: header; value; url")]
+    [TestCase(Headers.TokenAuthHeader, "faketoken", BaseUrls.TokenBaseUrl, TestName = "Validate does not throw: token header; value; token url")]
+    [TestCase(Headers.TrialAuthHeader, "faketoken", BaseUrls.TrialBaseUrl, TestName = "Validate does not throw: trial header; value; trial url")]
     public void Validate_DoesNotThrow(string? tokenHeader, string? tokenValue, string? url)
     {
         // Arrange
@@ -26,6 +29,8 @@ public class ElectricityMapsClientConfigurationTests
     [TestCase(null, "faketoken", "http://example.com", TestName = "Validate throws: no header; value; url")]
     [TestCase("x-token-header", null, "http://example.com", TestName = "Validate throws: no header; value; url")]
     [TestCase(null, null, "http://example.com", TestName = "Validate throws: no header; no value; url")]
+    [TestCase(Headers.TrialAuthHeader, "faketoken", BaseUrls.TokenBaseUrl, TestName = "Validate throws: trial header; value; token url")]
+    [TestCase(Headers.TokenAuthHeader, "faketoken", BaseUrls.TrialBaseUrl, TestName = "Validate throws: token header; value; trial url")]
     public void Validate_Throws(string? tokenHeader, string? tokenValue, string? url)
     {
         // Arrange


### PR DESCRIPTION
Issue Number: #266 

## Summary
ElectricityMaps enforces many restrictions on users with a free trial token. This PR ensures those restrictions are properly documented for SDK users and more error prevention measures are in place to catch issues.

## Changes

- Added documentation around restrictions
- Added more configuration validation to avoid invalid configurations between token/free trial users
- Added better error handling for failures free trial users may experience

## Checklist

- [X] Local Tests Passing?
- [X] CICD and Pipeline Tests Passing?
- [X] Added any new Tests?
- [X] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [ ] This is not a breaking change. If it is, please describe it below.

This PR Closes #266 
