### PR TITLE
Fixed encoding bug and added configuration test

### DIFF
--- a/src/CarbonAware.CLI/test/integrationTests/IntegrationTestingBase.cs
+++ b/src/CarbonAware.CLI/test/integrationTests/IntegrationTestingBase.cs
@@ -106,6 +106,8 @@ public abstract class IntegrationTestingBase
                 {
                     Environment.SetEnvironmentVariable("DataSources__EmissionsDataSource", "WattTime");
                     Environment.SetEnvironmentVariable("DataSources__ForecastDataSource", "WattTime");
+                    Environment.SetEnvironmentVariable("DataSources__Configurations__WattTime__Username", "username");
+                    Environment.SetEnvironmentVariable("DataSources__Configurations__WattTime__Password", "password");
                     Environment.SetEnvironmentVariable("DataSources__Configurations__WattTime__Type", "WattTime");
                     _dataSourceMocker = new WattTimeDataSourceMocker();
                     break;

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/src/Client/WattTimeClient.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/src/Client/WattTimeClient.cs
@@ -237,7 +237,7 @@ public class WattTimeClient : IWattTimeClient
 
     private void SetBasicAuthenticationHeader()
     {
-        var authToken = Encoding.ASCII.GetBytes($"{this.Configuration.Username}:{this.Configuration.Password}");
+        var authToken = Encoding.UTF8.GetBytes($"{this.Configuration.Username}:{this.Configuration.Password}");
         this.client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(AuthenticationHeaderTypes.Basic, Convert.ToBase64String(authToken));
     }
 

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/src/Configuration/WattTimeClientConfiguration.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/src/Configuration/WattTimeClientConfiguration.cs
@@ -1,5 +1,6 @@
 
 using CarbonAware.Exceptions;
+using System.Text;
 
 namespace CarbonAware.DataSources.WattTime.Configuration;
 
@@ -49,6 +50,17 @@ public class WattTimeClientConfiguration
         if (!Uri.IsWellFormedUriString(this.BaseUrl, UriKind.Absolute))
         {
             throw new ConfigurationException($"{Key}:{nameof(this.BaseUrl)} is not a valid absolute url.");
+        }
+
+        // Validate credential encoding/decoding with UTF8
+        if (!Encoding.UTF8.GetString(Encoding.UTF8.GetBytes(this.Username)).Equals(this.Username))
+        {
+            throw new ConfigurationException($"{Key}:{nameof(this.Username)} failed to be encoded/decoded with UTF8.");
+        }
+
+        if (!Encoding.UTF8.GetString(Encoding.UTF8.GetBytes(this.Password)).Equals(this.Password))
+        {
+            throw new ConfigurationException($"{Key}:{nameof(this.Password)} failed to be encoded/decoded with UTF8.");
         }
     }
 }

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/Client/WattTimeClientTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/Client/WattTimeClientTests.cs
@@ -46,7 +46,7 @@ public class WattTimeClientTests
 
         this.Options.Setup(o => o.CurrentValue).Returns(() => this.Configuration);
 
-        this.BasicAuthValue = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{this.Configuration.Username}:{this.Configuration.Password}"));
+        this.BasicAuthValue = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{this.Configuration.Username}:{this.Configuration.Password}"));
 
         this.Handler = new Mock<HttpMessageHandler>();
         this.HttpClientFactory = Handler.CreateClientFactory();

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/Configuration/WattTimeClientConfigurationTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/Configuration/WattTimeClientConfigurationTests.cs
@@ -29,7 +29,7 @@ public class WattTimeClientConfigurationTests
     [TestCase("testuser", null, "http://example.com", TestName = "Validate throws: no username; password; url")]
     [TestCase(null, null, "http://example.com", TestName = "Validate throws: no username; no password; url")]
     [TestCase("\ud800", null, "http://example.com", TestName = "Non utf8 characters for username")]
-    [TestCase(null, "\ud83e\udd70", "http://example.com", TestName = "Non utf8 characters for password")]
+    [TestCase("username", "\ud800", "http://example.com", TestName = "Non utf8 characters for password")]
 
     public void Validate_Throws(string? username, string? password, string? url)
     {

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/Configuration/WattTimeClientConfigurationTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/Configuration/WattTimeClientConfigurationTests.cs
@@ -28,6 +28,9 @@ public class WattTimeClientConfigurationTests
     [TestCase(null, "12345", "http://example.com", TestName = "Validate throws: no username; password; url")]
     [TestCase("testuser", null, "http://example.com", TestName = "Validate throws: no username; password; url")]
     [TestCase(null, null, "http://example.com", TestName = "Validate throws: no username; no password; url")]
+    [TestCase("\ud800", null, "http://example.com", TestName = "Non utf8 characters for username")]
+    [TestCase(null, "\ud83e\udd70", "http://example.com", TestName = "Non utf8 characters for password")]
+
     public void Validate_Throws(string? username, string? password, string? url)
     {
         // Arrange

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/Configuration/WattTimeClientConfigurationTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/Configuration/WattTimeClientConfigurationTests.cs
@@ -27,9 +27,7 @@ public class WattTimeClientConfigurationTests
     [TestCase("testuser", "12345", "not a url", TestName = "Validate throws: username; password; bad url")]
     [TestCase(null, "12345", "http://example.com", TestName = "Validate throws: no username; password; url")]
     [TestCase("testuser", null, "http://example.com", TestName = "Validate throws: no username; password; url")]
-    [TestCase(null, null, "http://example.com", TestName = "Validate throws: no username; no password; url")]
-    [TestCase("\ud800", null, "http://example.com", TestName = "Non utf8 characters for username")]
-    [TestCase("username", "\ud800", "http://example.com", TestName = "Non utf8 characters for password")]
+    [TestCase(null, "password", "http://example.com", TestName = "Validate throws: username; no password; url")]
 
     public void Validate_Throws(string? username, string? password, string? url)
     {
@@ -44,5 +42,19 @@ public class WattTimeClientConfigurationTests
 
         // Act & Assert
         Assert.Throws<ConfigurationException>(() => config.Validate());
+    }
+
+    // Needs to be separate test because passing TextCase arguments messes up UTF8 string.
+    [Test]
+    public void Validate_ThrowsForNonUtf8()
+    {
+        // Arrange
+        string nonUtf8 = "\ud800";
+        var nonUtf8Username_Config = new WattTimeClientConfiguration() { Username = nonUtf8, Password = "password", BaseUrl = "http://example.com" };
+        var nonUtf8Password_Config = new WattTimeClientConfiguration() { Username = "username", Password = nonUtf8, BaseUrl = "http://example.com" };
+
+        // Act & Assert
+        Assert.Throws<ConfigurationException>(() => nonUtf8Username_Config.Validate());
+        Assert.Throws<ConfigurationException>(() => nonUtf8Password_Config.Validate());
     }
 }

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/Configuration/WattTimeClientConfigurationTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/Configuration/WattTimeClientConfigurationTests.cs
@@ -8,6 +8,7 @@ namespace CarbonAware.DataSources.WattTime.Tests;
 public class WattTimeClientConfigurationTests
 {
     [TestCase("testuser", "12345", "http://example.com", TestName = "Validate does not throw: username; password; url")]
+    [TestCase("üsername", "password$1£", "http://example.com", TestName = "Validate does not throw; non-ASCII username; non-ASCII password; url")]
     public void Validate_DoesNotThrow(string? username, string? password, string? url)
     {
         // Arrange

--- a/src/CarbonAware.WebApi/test/integrationTests/IntegrationTestingBase.cs
+++ b/src/CarbonAware.WebApi/test/integrationTests/IntegrationTestingBase.cs
@@ -95,6 +95,8 @@ public abstract class IntegrationTestingBase
                 {
                     Environment.SetEnvironmentVariable("DataSources__EmissionsDataSource", "WattTime");
                     Environment.SetEnvironmentVariable("DataSources__ForecastDataSource", "WattTime");
+                    Environment.SetEnvironmentVariable("DataSources__Configurations__WattTime__Username", "username");
+                    Environment.SetEnvironmentVariable("DataSources__Configurations__WattTime__Password", "password");
                     Environment.SetEnvironmentVariable("DataSources__Configurations__WattTime__Type", "WattTime");
                     _dataSourceMocker = new WattTimeDataSourceMocker();
                     break;


### PR DESCRIPTION
Issue Number: #181 

## Summary
Fixed encoding bug that was causing WattTimeClient calls to fail when encoding non-ASCII characters in credentials.

## Changes

- Moved to UTF8 encoding scheme
- Added configuration checks and test to ensure we catch the failure if it occurs again

## Checklist

- [X] Local Tests Passing?
- [X] CICD and Pipeline Tests Passing?
- [X] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [ ] This is not a breaking change. If it is, please describe it below.

This PR Closes #181 