### PR TITLE
Update carbon-aware-webapi.md

### DIFF
--- a/docs/carbon-aware-webapi.md
+++ b/docs/carbon-aware-webapi.md
@@ -74,6 +74,11 @@ The response is an array of EmissionsData objects that contains the location, ti
     "location":"eastus"
     "time":"2022-05-17T20:45:11.5092741+00:00",
     "rating":70
+  },
+  {
+    "location":"westus"
+    "time":"2022-05-17T20:45:11.5092741+00:00",
+    "rating":64
   }
 ]
 ```


### PR DESCRIPTION
Adds a second object in the example JSON response for `/emissions/bylocations` to reflect the second queried location: "westus" (I'm assuming the `/emissions/bylocations` endpoint would return 1 `EmissionsData` object per requested location)