### PR TITLE
AzDo pipeline sample for GSF.CarbonAware package

### DIFF
--- a/samples/pipeline/azure/gsf-package.yml
+++ b/samples/pipeline/azure/gsf-package.yml
@@ -1,5 +1,10 @@
 # This is an example of an Azure DevOps pipeline
 # that builds GSF.CarbonAware nuget package and publish it as a pipeline artifact.
+parameters:
+- name: packageVersion
+  displayName: Package Version
+  type: string
+  default: 1.0.0-beta
 
 trigger:
 - main
@@ -45,7 +50,7 @@ steps:
       --output $(Build.ArtifactStagingDirectory)/packages/nuget
       -p:IncludeSymbols="true"
       -p:SymbolPackageFormat="snupkg"
-      -p:Version=1.2.3
+      -p:Version=${{ parameters.packageVersion }}
 
 # Alternatively, you can call the script to package the SDK. Replace the 2 tasks above (dotnet build and dotnet pack and replace with the following task) 
 # - task: Bash@3

--- a/samples/pipeline/azure/gsf-package.yml
+++ b/samples/pipeline/azure/gsf-package.yml
@@ -1,0 +1,69 @@
+# This is an example of an Azure DevOps pipeline
+# that builds GSF.CarbonAware nuget package and publish it as a pipeline artifact.
+
+trigger:
+- main
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+variables:
+  csproj: 'src/GSF.CarbonAware/src/GSF.CarbonAware.csproj'
+  buildConfiguration: 'Release'
+  ArtifactNuGetName: 'packages-nuget'
+  packageDir: '$(Build.ArtifactStagingDirectory)/packages/nuget'
+
+steps:
+- task: UseDotNet@2
+  displayName: 'Install .NET Core SDK'
+  inputs:
+    version: 6.x
+    performMultiLevelLookup: true
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet restore'
+  inputs:
+    command: restore
+    projects: '$(csproj)'
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet build $(buildConfiguration)'
+  inputs:
+    command: 'build'
+    projects: '$(csproj)'
+    arguments: >
+      --configuration $(buildConfiguration)
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet pack $(buildConfiguration)'
+  inputs:
+    command: custom
+    custom: pack
+    arguments: >
+      $(csproj)
+      --configuration $(buildConfiguration)
+      --output $(Build.ArtifactStagingDirectory)/packages/nuget
+      -p:IncludeSymbols="true"
+      -p:SymbolPackageFormat="snupkg"
+      -p:Version=1.2.3
+
+# Alternatively, you can call the script to package the SDK. Replace the 2 tasks above (dotnet build and dotnet pack and replace with the following task) 
+# - task: Bash@3
+#   displayName: 'Run script'
+#   inputs:
+#     targetType: 'filePath'
+#     filePath: "$(System.DefaultWorkingDirectory)/scripts/package/create_packages.sh"
+#     arguments: >
+#       $(csproj) $(packageDir)
+
+- task: Bash@3
+  displayName: List packages
+  inputs:
+    targetType: 'inline'
+    script: ls -l '$(Build.ArtifactStagingDirectory)/packages/nuget'
+
+- task: PublishPipelineArtifact@1
+  displayName: 'Publish Artifact: $(ArtifactNuGetName)'
+  inputs:
+    targetPath: '$(Build.ArtifactStagingDirectory)/packages/nuget'
+    artifactName: '$(ArtifactNuGetName)'


### PR DESCRIPTION
Issue Number: #268 

## Summary
Add example on how to create GSF.CarbonAware package using AzDo pipeline.

## Changes

- An example on how to build `GSF.CarbonAware` nuget package using Azure DevOps pipeline

## Anything else?

This PR Closes #268, microsoft/carbon-aware-sdk#245