### PR TITLE
Make the WattTime sample script always fetch data from last year

### DIFF
--- a/samples/watttime-registration/3-makerequest.py
+++ b/samples/watttime-registration/3-makerequest.py
@@ -1,14 +1,20 @@
 import requests
 from requests.auth import HTTPBasicAuth
 from settings import *
+from datetime import date
 
 login_url = 'https://api2.watttime.org/v2/login'
 token = requests.get(login_url, auth=HTTPBasicAuth(wt_username, wt_password)).json()['token']
 
 data_url = 'https://api2.watttime.org/v2/data'
 headers = {'Authorization': 'Bearer {}'.format(token)}
+
+last_year = str(date.today().year - 1)
+starttime = last_year + '-02-20T16:00:00-0800'
+endtime   = last_year + '-02-20T16:15:00-0800'
+
 params = {'ba': 'CAISO_NORTH', 
-          'starttime': '2019-02-20T16:00:00-0800', 
-          'endtime': '2019-02-20T16:15:00-0800'}
+          'starttime': starttime, 
+          'endtime': endtime}
 rsp = requests.get(data_url, headers=headers, params=params)
 print(rsp.text)


### PR DESCRIPTION
# Pull Request

Issue Number: #281

## Summary

Make the WattTime sample script always fetch data from last year.

## Changes

- Instead of fetching data for a hard-coded date (2019-02-21), choose that day (21 February) of last year, where "last year" is calculated based on the current date. This should prevent the situation where the API doesn't return anything because the requested data are too old.

## Are there API Changes?

No

## Is this a breaking change?

No

## Anything else?

The [readme file](https://github.com/Green-Software-Foundation/carbon-aware-sdk/blob/dev/samples/watttime-registration/readme.md) reports an example of the output. Clearly, since now the date is calculated and changes every year, the output in the documentation cannot be byte-for-byte identical to the one that you really get (we'd have to update the documentation every year). But I don't think it's relevant.

This PR Closes #281 
