### PR TITLE
Move CarbonAwareParameters to CarbonAware Project

### DIFF
--- a/src/CarbonAware.CLI/src/CarbonAware.CLI.csproj
+++ b/src/CarbonAware.CLI/src/CarbonAware.CLI.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="OpenTelemetry" Version="1.4.0-rc.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.10" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.4.0-rc.1" />
+    <PackageReference Include="System.IO.Filesystem" Version="4.3.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 

--- a/src/CarbonAware.CLI/src/Commands/Emissions/EmissionsCommand.cs
+++ b/src/CarbonAware.CLI/src/Commands/Emissions/EmissionsCommand.cs
@@ -1,7 +1,7 @@
 using CarbonAware.CLI.Common;
 using CarbonAware.CLI.Model;
 using GSF.CarbonAware.Handlers;
-using GSF.CarbonAware.Handlers.CarbonAware;
+using CarbonAware.Model;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;

--- a/src/CarbonAware.CLI/src/Commands/EmissionsForecasts/EmissionsForecastsCommand.cs
+++ b/src/CarbonAware.CLI/src/Commands/EmissionsForecasts/EmissionsForecastsCommand.cs
@@ -1,7 +1,7 @@
 ﻿using CarbonAware.CLI.Common;
 using CarbonAware.CLI.Model;
 using GSF.CarbonAware.Handlers;
-using GSF.CarbonAware.Handlers.CarbonAware;
+using CarbonAware.Model;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Text.Json;

--- a/src/CarbonAware.WebApi/src/Filters/CarbonAwareParametersBaseDtoOperationFilter.cs
+++ b/src/CarbonAware.WebApi/src/Filters/CarbonAwareParametersBaseDtoOperationFilter.cs
@@ -1,4 +1,4 @@
-using GSF.CarbonAware.Handlers.CarbonAware;
+using CarbonAware.Model;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
 

--- a/src/CarbonAware.WebApi/src/Filters/CarbonAwareParametersBaseDtoSchemaFilter.cs
+++ b/src/CarbonAware.WebApi/src/Filters/CarbonAwareParametersBaseDtoSchemaFilter.cs
@@ -1,4 +1,4 @@
-using GSF.CarbonAware.Handlers.CarbonAware;
+using CarbonAware.Model;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
 

--- a/src/CarbonAware.WebApi/src/Models/Parameters.CarbonIntensityBatchDTO.cs
+++ b/src/CarbonAware.WebApi/src/Models/Parameters.CarbonIntensityBatchDTO.cs
@@ -1,4 +1,4 @@
-using GSF.CarbonAware.Handlers.CarbonAware;
+using CarbonAware.Model;
 using System.Text.Json.Serialization;
 using Swashbuckle.AspNetCore.Annotations;
 

--- a/src/CarbonAware.WebApi/src/Models/Parameters.CarbonIntensityDTO.cs
+++ b/src/CarbonAware.WebApi/src/Models/Parameters.CarbonIntensityDTO.cs
@@ -1,4 +1,4 @@
-using GSF.CarbonAware.Handlers.CarbonAware;
+using CarbonAware.Model;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 

--- a/src/CarbonAware.WebApi/src/Models/Parameters.EmissionsDataForLocationsDTO.cs
+++ b/src/CarbonAware.WebApi/src/Models/Parameters.EmissionsDataForLocationsDTO.cs
@@ -1,4 +1,4 @@
-using GSF.CarbonAware.Handlers.CarbonAware;
+using CarbonAware.Model;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 

--- a/src/CarbonAware.WebApi/src/Models/Parameters.EmissionsForecastBatchDTO.cs
+++ b/src/CarbonAware.WebApi/src/Models/Parameters.EmissionsForecastBatchDTO.cs
@@ -1,4 +1,4 @@
-using GSF.CarbonAware.Handlers.CarbonAware;
+using CarbonAware.Model;
 using System.Text.Json.Serialization;
 using Swashbuckle.AspNetCore.Annotations;
 

--- a/src/CarbonAware.WebApi/src/Models/Parameters.EmissionsForecastCurrentDTO.cs
+++ b/src/CarbonAware.WebApi/src/Models/Parameters.EmissionsForecastCurrentDTO.cs
@@ -1,4 +1,4 @@
-using GSF.CarbonAware.Handlers.CarbonAware;
+using CarbonAware.Model;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 

--- a/src/CarbonAware/src/CarbonAware.csproj
+++ b/src/CarbonAware/src/CarbonAware.csproj
@@ -10,10 +10,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" />
-    <PackageReference Include="Microsoft.Extensions.Configuration"/>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
-    <PackageReference Include="Microsoft.Extensions.Hosting"/>
-    <PackageReference Include="System.ComponentModel.Composition"/>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+	  
+    <ItemGroup>
+    <InternalsVisibleTo Include="GSF.CarbonAware" />
   </ItemGroup>
 
 </Project>

--- a/src/CarbonAware/src/Model/CarbonAwareParameters.cs
+++ b/src/CarbonAware/src/Model/CarbonAwareParameters.cs
@@ -1,8 +1,7 @@
-using CarbonAware.Model;
 using Microsoft.AspNetCore.Mvc;
 using System.Text.Json.Serialization;
 
-namespace GSF.CarbonAware.Handlers.CarbonAware;
+namespace CarbonAware.Model;
 
 public class CarbonAwareParametersBaseDTO
 {

--- a/src/GSF.CarbonAware/src/Handlers/EmissionsHandler.cs
+++ b/src/GSF.CarbonAware/src/Handlers/EmissionsHandler.cs
@@ -1,10 +1,10 @@
 using CarbonAware.Exceptions;
 using CarbonAware.Extensions;
 using CarbonAware.Interfaces;
-using GSF.CarbonAware.Handlers.CarbonAware;
-using GSF.CarbonAware.Models;
+using CarbonAware.Model;
 using Microsoft.Extensions.Logging;
-using static GSF.CarbonAware.Handlers.CarbonAware.CarbonAwareParameters;
+using static CarbonAware.Model.CarbonAwareParameters;
+using EmissionsData = GSF.CarbonAware.Models.EmissionsData;
 
 namespace GSF.CarbonAware.Handlers;
 

--- a/src/GSF.CarbonAware/src/Handlers/ForecastHandler.cs
+++ b/src/GSF.CarbonAware/src/Handlers/ForecastHandler.cs
@@ -2,10 +2,10 @@ using CarbonAware;
 using CarbonAware.Exceptions;
 using CarbonAware.Extensions;
 using CarbonAware.Interfaces;
-using GSF.CarbonAware.Handlers.CarbonAware;
-using GSF.CarbonAware.Models;
+using CarbonAware.Model;
 using Microsoft.Extensions.Logging;
-using static GSF.CarbonAware.Handlers.CarbonAware.CarbonAwareParameters;
+using static CarbonAware.Model.CarbonAwareParameters;
+using EmissionsForecast = GSF.CarbonAware.Models.EmissionsForecast;
 
 namespace GSF.CarbonAware.Handlers;
 

--- a/src/GSF.CarbonAware/test/EmissionsHandlerTests.cs
+++ b/src/GSF.CarbonAware/test/EmissionsHandlerTests.cs
@@ -1,17 +1,14 @@
-
+using CarbonAware.Interfaces;
+using CarbonAware.Model;
 using EmissionsData = CarbonAware.Model.EmissionsData;
 using GSF.CarbonAware.Exceptions;
 using GSF.CarbonAware.Handlers;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
-using System;
-using CarbonAware.Interfaces;
-using GSF.CarbonAware.Handlers.CarbonAware;
-using System.Collections;
-using CarbonAware.Model;
 using System.Collections.Generic;
 
 namespace GSF.CarbonAware.Tests;

--- a/src/GSF.CarbonAware/test/LocationHandlerTests.cs
+++ b/src/GSF.CarbonAware/test/LocationHandlerTests.cs
@@ -1,9 +1,9 @@
+using CarbonAware.Interfaces;
 using GSF.CarbonAware.Handlers;
 using Moq;
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using CarbonAware.Interfaces;
 using System.Collections.Immutable;
 
 namespace GSF.CarbonAware.Tests;


### PR DESCRIPTION
Issue Number: #284 

## Summary
Move the `CarbonAwareParameters` class to the `CarbonAware` project

## Changes

- Move class to CarbonAware project
- Update references

## Checklist

- [X] Local Tests Passing?
- [X] CICD and Pipeline Tests Passing?
- [X] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [x] This is not a breaking change. If it is, please describe it below.



This PR Closes #284 
