### PR TITLE
[Bug] 403 error is surfaced as 500 Internal

### DIFF
--- a/src/CarbonAware.CLI/src/Commands/Location/LocationsCommand.cs
+++ b/src/CarbonAware.CLI/src/Commands/Location/LocationsCommand.cs
@@ -1,4 +1,4 @@
-﻿using CarbonAware.Interfaces;
+﻿using GSF.CarbonAware.Handlers;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Text.Json;
@@ -15,9 +15,9 @@ public class LocationsCommand : Command
     internal async Task Run(InvocationContext context)
     {
         var serviceProvider = context.BindingContext.GetService(typeof(IServiceProvider)) as IServiceProvider ?? throw new NullReferenceException("ServiceProvider not found");
-        var locationSource = serviceProvider.GetService(typeof(ILocationSource)) as ILocationSource ?? throw new NullReferenceException("ILocationSource not found");
+        var locationSource = serviceProvider.GetService(typeof(ILocationHandler)) as ILocationHandler ?? throw new NullReferenceException("ILocationHandler not found");
 
-        var locations = await locationSource.GetGeopositionLocationsAsync();
+        var locations = await locationSource.GetLocationsAsync();
         var serializedOuput = JsonSerializer.Serialize(locations);
         context.Console.WriteLine(serializedOuput);
         context.ExitCode = 0;

--- a/src/CarbonAware.CLI/test/unitTests/Commands/Location/LocationCommandTests.cs
+++ b/src/CarbonAware.CLI/test/unitTests/Commands/Location/LocationCommandTests.cs
@@ -1,7 +1,7 @@
 ﻿using CarbonAware.CLI.Commands.Location;
+using GSF.CarbonAware.Models;
 using Moq;
 using NUnit.Framework;
-using CarbonAware.Model;
 
 namespace CarbonAware.CLI.UnitTests;
 
@@ -25,7 +25,7 @@ public class LocationCommandTests : TestBase
             }
         };
 
-        _mockLocationSource.Setup(ls => ls.GetGeopositionLocationsAsync())
+        _mockLocationHandler.Setup(ls => ls.GetLocationsAsync())
             .ReturnsAsync(expectedLocations);
 
         // Act
@@ -38,6 +38,6 @@ public class LocationCommandTests : TestBase
             StringAssert.Contains(location, consoleOutput);
         }
 
-        _mockLocationSource.Verify(ls => ls.GetGeopositionLocationsAsync(), Times.Once);
+        _mockLocationHandler.Verify(ls => ls.GetLocationsAsync(), Times.Once);
     }
 }

--- a/src/CarbonAware.CLI/test/unitTests/TestBase.cs
+++ b/src/CarbonAware.CLI/test/unitTests/TestBase.cs
@@ -1,11 +1,9 @@
 using Moq;
 using GSF.CarbonAware.Handlers;
-using GSF.CarbonAware.Models;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using System.CommandLine.IO;
-using CarbonAware.Interfaces;
 
 namespace CarbonAware.CLI.UnitTests;
 
@@ -16,7 +14,7 @@ public abstract class TestBase
 {
     protected Mock<IForecastHandler> _mockForecastHandler = new();
     protected Mock<IEmissionsHandler> _mockEmissionsHandler = new();
-    protected Mock<ILocationSource> _mockLocationSource = new();
+    protected Mock<ILocationHandler> _mockLocationHandler = new();
 
 
     protected readonly TestConsole _console = new();
@@ -25,7 +23,7 @@ public abstract class TestBase
     {
         _mockEmissionsHandler = new Mock<IEmissionsHandler>();
         _mockForecastHandler = new Mock<IForecastHandler>();
-        _mockLocationSource = new Mock<ILocationSource>();
+        _mockLocationHandler = new Mock<ILocationHandler>();
 
         var parser = new Parser(command);
         var parseResult = parser.Parse(stringCommand);
@@ -38,8 +36,8 @@ public abstract class TestBase
         mockServiceProvider.Setup(x => x.GetService(typeof(IForecastHandler)))
             .Returns(_mockForecastHandler.Object);
 
-        mockServiceProvider.Setup(x => x.GetService(typeof(ILocationSource)))
-            .Returns(_mockLocationSource.Object);
+        mockServiceProvider.Setup(x => x.GetService(typeof(ILocationHandler)))
+            .Returns(_mockLocationHandler.Object);
 
         invocationContext.BindingContext.AddService<IServiceProvider>(_ => mockServiceProvider.Object);
 

--- a/src/CarbonAware.WebApi/src/Filters/HttpResponseExceptionFilter.cs
+++ b/src/CarbonAware.WebApi/src/Filters/HttpResponseExceptionFilter.cs
@@ -31,7 +31,7 @@ public class HttpResponseExceptionFilter : IExceptionFilter
         var activity = Activity.Current;
 
         HttpValidationProblemDetails response;
-        var contextException = GetRelevantExceptionFromContext(context);
+        var contextException = GetRelevantException(context);
         if (contextException is IHttpResponseException httpResponseException)
         {
             response = new HttpValidationProblemDetails(){
@@ -90,7 +90,7 @@ public class HttpResponseExceptionFilter : IExceptionFilter
         context.ExceptionHandled = true;
     }
 
-    private static Exception GetRelevantExceptionFromContext(ExceptionContext context)
+    private static Exception GetRelevantException(ExceptionContext context)
     {
         // Give priority to the inner exception since it contains the exception root cause.
         if (context.Exception.InnerException is not null)


### PR DESCRIPTION
Issue Number: (#286)

## Summary

After WebApi and CLI integration with GSF library (#245, #270) , relevant exceptions coming from providers were displayed as 500 internal error for the WebApi for instance. Root cause wasn't displayed.
This PR fixes this regression, bringing back the root cause of the error.

## Changes

- Extract inner exception in case there is one as part of error handling done by the http/error handling filter class.

## Checklist

- [x] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?

This PR Closes #286, microsoft/carbon-aware-sdk#256
