### PR TITLE
Unit tests must convert floats to strings in a culture-independent way

### DIFF
--- a/src/CarbonAware.CLI/test/unitTests/Commands/Emissions/EmissionsCommandTests.cs
+++ b/src/CarbonAware.CLI/test/unitTests/Commands/Emissions/EmissionsCommandTests.cs
@@ -4,6 +4,7 @@ using GSF.CarbonAware.Models;
 using Moq;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
+using System.Globalization;
 
 namespace CarbonAware.CLI.UnitTests;
 
@@ -34,7 +35,7 @@ public class EmissionsCommandTests : TestBase
         // Assert
         string? consoleOutput = _console.Out.ToString();
         StringAssert.Contains(expectedEmissions.Location, consoleOutput);
-        StringAssert.Contains(expectedEmissions.Rating.ToString(), consoleOutput);
+        StringAssert.Contains(expectedEmissions.Rating.ToString(CultureInfo.InvariantCulture), consoleOutput);
         StringAssert.Contains(expectedEmissions.Time.ToString("yyyy-MM-ddTHH:mm:sszzz"), consoleOutput);
         StringAssert.Contains(expectedEmissions.Duration.ToString(), consoleOutput);
        

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/Client/WattTimeClientTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/Client/WattTimeClientTests.cs
@@ -7,6 +7,7 @@ using Moq;
 using Moq.Contrib.HttpClient;
 using NUnit.Framework;
 using System;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -134,7 +135,7 @@ public class WattTimeClientTests
         Assert.AreEqual(300, gridDataPoint.Frequency);
         Assert.AreEqual("mkt", gridDataPoint.Market);
         Assert.AreEqual(new DateTimeOffset(2099, 1, 1, 0, 0, 0, TimeSpan.Zero), gridDataPoint.PointTime);
-        Assert.AreEqual("999.99", gridDataPoint.Value.ToString("0.00")); //Format float to avoid precision issues
+        Assert.AreEqual("999.99", gridDataPoint.Value.ToString("0.00", CultureInfo.InvariantCulture)); //Format float to avoid precision issues
         Assert.AreEqual("1.0", gridDataPoint.Version);
     }
 
@@ -192,7 +193,7 @@ public class WattTimeClientTests
         var forecastDataPoint = forecast?.ForecastData.First();
         Assert.AreEqual("ba", forecastDataPoint?.BalancingAuthorityAbbreviation);
         Assert.AreEqual(new DateTimeOffset(2099, 1, 1, 0, 0, 0, TimeSpan.Zero), forecastDataPoint?.PointTime);
-        Assert.AreEqual("999.99", forecastDataPoint?.Value.ToString("0.00")); //Format float to avoid precision issues
+        Assert.AreEqual("999.99", forecastDataPoint?.Value.ToString("0.00", CultureInfo.InvariantCulture)); //Format float to avoid precision issues
         Assert.AreEqual("1.0", forecastDataPoint?.Version);
     }
 
@@ -258,7 +259,7 @@ public class WattTimeClientTests
         var forecastDataPoint = forecast.ForecastData.ToList().First();
         Assert.AreEqual("ba", forecastDataPoint.BalancingAuthorityAbbreviation);
         Assert.AreEqual(new DateTimeOffset(2099, 1, 1, 0, 0, 0, TimeSpan.Zero), forecastDataPoint.PointTime);
-        Assert.AreEqual("999.99", forecastDataPoint.Value.ToString("0.00")); //Format float to avoid precision issues
+        Assert.AreEqual("999.99", forecastDataPoint.Value.ToString("0.00", CultureInfo.InvariantCulture)); //Format float to avoid precision issues
         Assert.AreEqual("1.0", forecastDataPoint.Version);
     }
 

--- a/src/CarbonAware.LocationSources/test/Model/NamedGeopositionTests.cs
+++ b/src/CarbonAware.LocationSources/test/Model/NamedGeopositionTests.cs
@@ -40,7 +40,7 @@ class NamedGeopositionTests
         if (!string.IsNullOrWhiteSpace(latitude))
         {
             Assert.NotNull(location.Latitude);
-            Assert.AreEqual(latitude, location.Latitude.ToString());
+            Assert.AreEqual(latitude, location.LatitudeAsCultureInvariantString());
         }
         else
         {
@@ -50,7 +50,7 @@ class NamedGeopositionTests
         if (!string.IsNullOrWhiteSpace(longitude))
         {
             Assert.NotNull(location.Longitude);
-            Assert.AreEqual(longitude, location.Longitude.ToString());
+            Assert.AreEqual(longitude, location.LongitudeAsCultureInvariantString());
         }
         else
         {


### PR DESCRIPTION
# Pull Request

Issue Number: #295

## Summary

Unit tests must convert floats to strings in a culture-independent way

## Changes

Fixed some tests in:

- src/CarbonAware.CLI/test/unitTests/Commands/Emissions/EmissionsCommandTests.cs
- src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/test/Client/WattTimeClientTests.cs
- src/CarbonAware.LocationSources/test/Model/NamedGeopositionTests.cs

This PR Closes #295
