### PR TITLE
WebAPI: Bugfix: Add 'application/json; charset=utf-8' to Produces annotations.

### DIFF
--- a/src/CarbonAware.WebApi/src/Controllers/CarbonAwareController.cs
+++ b/src/CarbonAware.WebApi/src/Controllers/CarbonAwareController.cs
@@ -34,7 +34,7 @@ public class CarbonAwareController : ControllerBase
     /// </summary>
     /// <param name="parameters">The request object <see cref="EmissionsDataForLocationsParametersDTO"/></param>
     /// <returns>Array of EmissionsData objects that contains the location, time and the rating in g/kWh</returns>
-    [Produces("application/json")]
+    [Produces("application/json", "application/json; charset=utf-8")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<EmissionsData>))]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ValidationProblemDetails))]
@@ -50,7 +50,7 @@ public class CarbonAwareController : ControllerBase
     /// </summary>
     /// <param name="parameters">The request object <see cref="EmissionsDataForLocationsParametersDTO"/></param>
     /// <returns>Array of EmissionsData objects that contains the location, time and the rating in g/kWh</returns>
-    [Produces("application/json")]
+    [Produces("application/json", "application/json; charset=utf-8")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<EmissionsData>))]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ValidationProblemDetails))]
@@ -68,7 +68,7 @@ public class CarbonAwareController : ControllerBase
     /// <param name="startTime"> [Optional] Start time for the data query.</param>
     /// <param name="endTime"> [Optional] End time for the data query.</param>
     /// <returns>Array of EmissionsData objects that contains the location, time and the rating in g/kWh</returns>
-    [Produces("application/json")]
+    [Produces("application/json", "application/json; charset=utf-8")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<EmissionsData>))]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ValidationProblemDetails))]
@@ -107,7 +107,7 @@ public class CarbonAwareController : ControllerBase
     /// <response code="400">Returned if any of the input parameters are invalid</response>
     /// <response code="500">Internal server error</response>
     /// <response code="501">Returned if the underlying data source does not support forecasting</response>
-    [Produces("application/json")]
+    [Produces("application/json", "application/json; charset=utf-8")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<EmissionsForecastDTO>))]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ValidationProblemDetails))]
     [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ValidationProblemDetails))]
@@ -138,7 +138,7 @@ public class CarbonAwareController : ControllerBase
     /// <response code="400">Returned if any of the input parameters are invalid</response>
     /// <response code="500">Internal server error</response>
     /// <response code="501">Returned if the underlying data source does not support forecasting</response>
-    [Produces("application/json")]
+    [Produces("application/json", "application/json; charset=utf-8")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<EmissionsForecastDTO>))]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ValidationProblemDetails))]
     [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ValidationProblemDetails))]
@@ -172,7 +172,7 @@ public class CarbonAwareController : ControllerBase
     /// <response code="200">Returns a single object that contains the information about the request and the average marginal carbon intensity</response>
     /// <response code="400">Returned if any of the requested items are invalid</response>
     /// <response code="500">Internal server error</response>
-    [Produces("application/json")]
+    [Produces("application/json", "application/json; charset=utf-8")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CarbonIntensityDTO))]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ValidationProblemDetails))]
     [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ValidationProblemDetails))]
@@ -209,7 +209,7 @@ public class CarbonAwareController : ControllerBase
     /// <response code="200">Returns an array of objects where each contains location, time boundaries and the corresponding average marginal carbon intensity</response>
     /// <response code="400">Returned if any of the requested items are invalid</response>
     /// <response code="500">Internal server error</response>
-    [Produces("application/json")]
+    [Produces("application/json", "application/json; charset=utf-8")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<CarbonIntensityDTO>))]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ValidationProblemDetails))]
     [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ValidationProblemDetails))]


### PR DESCRIPTION
* Issue reference: #198
* Produces filters now accept application/json; charset=utf-8

# Pull Request

Issue Number: #198 

## Summary

Fix allows OpenAPI generated SDKs (namely - Python library) to accept responses from the API. It adds an annotation to the produced output from the CA API endpoints, so the generated libraries can consume them as well. See #198 how this failed before.

## Changes

- Change annotations in WebAPI Controllers

## Checklist

- [x] Local Tests Passing?
- [ ] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [x] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?

If yes, what are the expected API Changes? Please link to an API-Comparison
workflow with the API Diff.

## Is this a breaking change?

If yes, what workflow does this break?

## Anything else?

Other comments, collaborators, etc.

> Please follow
> [GitHub's suggested syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
> to link Pull Requests to Issues via keywords

This PR Closes #198 
