### PR TITLE
Create stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,30 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '25 6 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'Stale issue message'
+        stale-pr-message: 'Stale pull request message'
+        stale-issue-label: 'no-issue-activity'
+        stale-pr-label: 'no-pr-activity'
+        days-before-issue-stale: 240 #5 months old - initial value aimed to be reduced in the short terms
+        days-before-issue-close: 20
+        days-before-pr-stale: 120

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,10 +21,11 @@ jobs:
     - uses: actions/stale@v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'Stale issue message'
-        stale-pr-message: 'Stale pull request message'
+        stale-issue-message: 'This issue has not had any activity in 240 days. Please review this issue and ensure it is still relevant. If no more activity is detected on this issue for the next 20 days, it will be closed automatically.'
+        close-issue-message: 'This issue has not had any activity for too long. If you believe this issue has been closed in error, please contact an administrator to re-open, or if absolutly relevant and necessary, create a new issue referencing this one. '
+        stale-pr-message: 'This a stale pull request. Please review, update or/and close as necessary.'
         stale-issue-label: 'no-issue-activity'
         stale-pr-label: 'no-pr-activity'
-        days-before-issue-stale: 240 #5 months old - initial value aimed to be reduced in the short terms
+        days-before-issue-stale: 240 #6 months old - initial value aimed to be reduced in the short terms
         days-before-issue-close: 20
         days-before-pr-stale: 120


### PR DESCRIPTION
Create a workflow to warn and then close issues that have had no activity for a specified amount of time. Warning for stale also expected on PRs older than ~3 months

# Pull Request

Issue Number: [(Link to Github Issue or Azure Dev Ops Task/Story)](https://github.com/Green-Software-Foundation/carbon-aware-sdk/issues/318)

## Summary

Clean up workflow for old issues and features

## Changes

- Mark old issues (6 months) and PRs (3 months) as stale.
- Close issues that had no activity in the 30 days after being labeled stale.

## Checklist

- [ ] Local Tests Passing?
- [ ] CICD and Pipeline Tests Passing?
- [ ] Documentation Updates Made?
- [X] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?

No

## Is this a breaking change?

No

## Anything else?

Other comments, collaborators, etc.

> Please follow
> [GitHub's suggested syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
> to link Pull Requests to Issues via keywords

This PR Closes #318 
