### PR TITLE
Shorten stale issues by 2 months and stale label to 'stale'

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,7 +25,7 @@ jobs:
         close-issue-message: 'This issue has not had any activity for too long. If you believe this issue has been closed in error, please contact an administrator to re-open, or if absolutly relevant and necessary, create a new issue referencing this one. '
         stale-pr-message: 'This a stale pull request. Please review, update or/and close as necessary.'
         stale-issue-label: 'stale'
-        stale-pr-label: 'stale-pr'
+        stale-pr-label: 'stale'
         days-before-issue-stale: 120 #4 months old - initial value aimed to be reduced in the short terms
         days-before-issue-close: 20
         days-before-pr-stale: 120

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,11 +21,11 @@ jobs:
     - uses: actions/stale@v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue has not had any activity in 240 days. Please review this issue and ensure it is still relevant. If no more activity is detected on this issue for the next 20 days, it will be closed automatically.'
+        stale-issue-message: 'This issue has not had any activity in 120 days. Please review this issue and ensure it is still relevant. If no more activity is detected on this issue for the next 20 days, it will be closed automatically.'
         close-issue-message: 'This issue has not had any activity for too long. If you believe this issue has been closed in error, please contact an administrator to re-open, or if absolutly relevant and necessary, create a new issue referencing this one. '
         stale-pr-message: 'This a stale pull request. Please review, update or/and close as necessary.'
-        stale-issue-label: 'no-issue-activity'
-        stale-pr-label: 'no-pr-activity'
-        days-before-issue-stale: 240 #6 months old - initial value aimed to be reduced in the short terms
+        stale-issue-label: 'stale'
+        stale-pr-label: 'stale-pr'
+        days-before-issue-stale: 120 #4 months old - initial value aimed to be reduced in the short terms
         days-before-issue-close: 20
         days-before-pr-stale: 120


### PR DESCRIPTION
Issues to be stale from 120 days of no activity
Label to change to stale and stale-pr to be more explicit

# Pull Request

Issue Number: [(Link to Github Issue or Azure Dev Ops Task/Story)](https://github.com/Green-Software-Foundation/carbon-aware-sdk/issues/318)

## Summary

Shorten stale issues by 2 months and stale label to 'stale'

## Changes

- Issues to be stale from 120 days of no activity
- Label to change to stale and stale-pr to be more explicit

## Checklist

- [ ] Local Tests Passing?
- [ ] CICD and Pipeline Tests Passing?
- [ ] Documentation Updates Made?
- [X] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?

No

## Is this a breaking change?

No

## Anything else?

Other comments, collaborators, etc.

> Please follow
> [GitHub's suggested syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
> to link Pull Requests to Issues via keywords

This PR is related to [(Link to Github Issue or Azure Dev Ops Task/Story)](https://github.com/Green-Software-Foundation/carbon-aware-sdk/issues/318)
