### PR TITLE
updated stale property of operations-per-run

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,3 +29,4 @@ jobs:
         days-before-issue-stale: 120 #4 months old - initial value aimed to be reduced in the short terms
         days-before-issue-close: 20
         days-before-pr-stale: 120
+        operations-per-run: 55 #was not processing all the issues and some issues that should have been stale were missed. This value based on current number of issues (43) and PRs (10)


### PR DESCRIPTION
Updated Stale workflow to process more items.
We are trying to figure out the optimal value and what the job's stat signify so this may increase further.

# Pull Request

Issue Number: (Link to Github Issue or Azure Dev Ops Task/Story)

## Summary

One sentence summary of PR

## Changes

- List of comprehensive changes

## Checklist

- [ ] Local Tests Passing?
- [ ] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [ ] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?

If yes, what are the expected API Changes? Please link to an API-Comparison
workflow with the API Diff.

## Is this a breaking change?

If yes, what workflow does this break?

## Anything else?

Other comments, collaborators, etc.

> Please follow
> [GitHub's suggested syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
> to link Pull Requests to Issues via keywords

This PR Closes #<issue_number>
