### PR TITLE
Use PowerShell in 2-pre-release.yaml

### DIFF
--- a/.github/workflows/2-pre-release.yaml
+++ b/.github/workflows/2-pre-release.yaml
@@ -56,11 +56,7 @@ jobs:
           $image_lower = "${{ env.IMAGE_NAME }}".ToLower()
 
           # Retrieve information of all of container images
-          $headers = @{"Authorization" = "Bearer ${{ github.token }}";
-                       "Accept" = "application/vnd.github+json";
-                       "X-GitHub-Api-Version" = "2022-11-28"}
-          $versions = Invoke-WebRequest -Headers $headers https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/${{ env.PACKAGE_NAME }}/versions |
-              ConvertFrom-Json
+          $versions = gh api orgs/${{ github.repository_owner }}/packages/container/${{ env.PACKAGE_NAME }}/versions | ConvertFrom-Json
 
           $digests = New-Object System.Collections.Generic.HashSet[string]
           # Pick up digest of tagged images which should be removed

--- a/.github/workflows/2-pre-release.yaml
+++ b/.github/workflows/2-pre-release.yaml
@@ -51,25 +51,46 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           provenance: false
       - name: List older container images to remove
+        id: list-older-images
         run: |
-          JSON=`curl -sL -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ github.token }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/${{ env.PACKAGE_NAME }}/versions`
-          TAGS=(`echo "$JSON" | jq -r '[.[] | select((.metadata.container.tags | length) > 0)] | sort_by(.created_at) | reverse | .[].metadata.container.tags[0] | select(startswith("sha-"))'`)
-          for TAG in "${TAGS[@]:${{ env.NUM_KEEP_IMAGES }}}"; do
-            PARENT_SHA=`echo "$JSON" | jq -r ".[] | select(.metadata.container.tags | contains([\"$TAG\"])) | .name"`
-            PARENT_ID=`echo "$JSON" | jq -r ".[] | select(.name == \"$PARENT_SHA\") | .id"`
-            echo "$PARENT_ID" >> stale-images.txt
-            PLATFORM_SHAS=(`docker manifest inspect ghcr.io/${{ env.IMAGE_NAME }}@$PARENT_SHA | jq -r '.manifests[].digest'`)
-            for SHA in "${PLATFORM_SHAS[@]}"; do
-              CHILD_ID=`echo "$JSON" | jq -r ".[] | select(.name == \"$SHA\") | .id"`
-              echo "$CHILD_ID" >> stale-images.txt
-            done
-          done
+          $image_lower = "${{ env.IMAGE_NAME }}".ToLower()
 
-          STALE_LIST=`cat stale-images.txt | sed -z 's/\n/,/g' | sed -e 's/,$//'`
-          echo "STALE_LIST=$STALE_LIST" >> $GITHUB_ENV
+          # Retrieve information of all of container images
+          $headers = @{"Authorization" = "Bearer ${{ github.token }}";
+                       "Accept" = "application/vnd.github+json";
+                       "X-GitHub-Api-Version" = "2022-11-28"}
+          $versions = Invoke-WebRequest -Headers $headers https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/${{ env.PACKAGE_NAME }}/versions |
+              ConvertFrom-Json
+
+          $digests = New-Object System.Collections.Generic.HashSet[string]
+          # Pick up digest of tagged images which should be removed
+          $versions |
+              Where-Object {$_.metadata.container.tags.Where({$_.StartsWith("sha-")}, "First").Count -gt 0} |
+              Sort-Object -Property created_at -Descending |
+              Select-Object -Skip ${{ env.NUM_KEEP_IMAGES }} |
+              ForEach-Object {[void]$digests.add($_.name)}
+
+          # Pick up digest of children tagged images which should be removed
+          $loop_set = New-Object System.Collections.Generic.HashSet[string]($digests)
+          $loop_set.foreach{
+            docker manifest inspect "${{ env.REGISTRY }}/$image_lower@$_" |
+            Out-String |
+            ConvertFrom-Json |
+            Select-Object -ExpandProperty "manifests" |
+            ForEach-Object {[void]$digests.Add($_.digest)}
+          }
+
+          # Retrieve IDs to be removed
+          $ids = $versions |
+              Where-Object {$digests.Contains($_.name)} |
+              Select-Object -ExpandProperty id
+
+          $remove_images = $ids -join ","
+          "REMOVE_IMAGES=$remove_images" >> $env:GITHUB_OUTPUT
+        shell: pwsh
       - name: Remove stale packages
         uses: actions/delete-package-versions@v4
         with:
           package-name: carbon-aware-sdk
           package-type: container
-          package-version-ids: ${{ env.STALE_LIST }}
+          package-version-ids: ${{ steps.list-older-images.outputs.REMOVE_IMAGES }}


### PR DESCRIPTION
# Pull Request

## Summary

Proposal to use PowerShell rather than bash for package generation management.

Currently 2-pre-release.yaml uses bash to remove older container images because we need to keep recent 3 container images. GitHub Marketplace provides some useful actions for package management, but they are not track multi-arch container images. We need to manage both AMD64 and Arm64 container images. So we need to manage manually now.

I implemented it in bash in #327, but  it is a bit complex, so I'd like to propose to rewrite it in PowerShell. IMHO PowerShell is minor than bash, so I'm concerned the maintainer can maintain the workflow. Thus I'm not going to propose it strongly, but I think it is worth to discuss.

## Changes

- `list-older-images` step in 2-pre-release.yaml

## Checklist

- [x] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [x] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?

No

## Is this a breaking change?

No

> Please follow
> [GitHub's suggested syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
> to link Pull Requests to Issues via keywords
