### PR TITLE
Add 4-release.yaml to publish container image for the release

### DIFF
--- a/.github/workflows/4-release.yaml
+++ b/.github/workflows/4-release.yaml
@@ -1,0 +1,43 @@
+name: Publish container image to GitHub Packages
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  publish-container-image:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4.3.0
+        with:
+          flavor: latest=true
+          tags: type=raw,value=${{ github.ref_name }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: "{{defaultContext}}:src"
+          file: CarbonAware.WebApi/src/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: false


### PR DESCRIPTION
# Pull Request

#252

## Summary

Add 4-release.yaml to ship container image of the release.

This workflow would be triggered when the maintainer creates new release on GitHub release page. The container image has both `latest` and release version tag. Container image is for both AMD64 and Arm64, and they are pushlished to GitHub Packages.

You can see an example on my forked repo: https://github.com/YaSuenag/carbon-aware-sdk/pkgs/container/carbon-aware-sdk/88739206?tag=v99.0.23

## Changes

- .github/workflows/4-release.yaml (new)

## Checklist

- [ ] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [x] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?

No

## Is this a breaking change?

No