### PR TITLE
Skip deploy workflows in forked repos

### DIFF
--- a/.github/workflows/2-pre-release.yaml
+++ b/.github/workflows/2-pre-release.yaml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   publish-container-image:
-    if: github.repository == 'Green-Software-Foundation/carbon-aware-sdk'
+    if: github.repository == 'Green-Software-Foundation/carbon-aware-sdk' || vars.ENABLE_PRERELEASE_WORKFLOW == 'true'
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.github/workflows/2-pre-release.yaml
+++ b/.github/workflows/2-pre-release.yaml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   publish-container-image:
+    if: github.repository == 'Green-Software-Foundation/carbon-aware-sdk'
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.github/workflows/dev_carbon-aware-api.yml
+++ b/.github/workflows/dev_carbon-aware-api.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    if: github.repository == 'Green-Software-Foundation/carbon-aware-sdk'
+    if: github.repository == 'Green-Software-Foundation/carbon-aware-sdk' || vars.ENABLE_WEBAPP_WORKFLOW == 'true'
     runs-on: windows-latest
 
     steps:

--- a/.github/workflows/dev_carbon-aware-api.yml
+++ b/.github/workflows/dev_carbon-aware-api.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'Green-Software-Foundation/carbon-aware-sdk'
     runs-on: windows-latest
 
     steps:


### PR DESCRIPTION
# Pull Request

## Summary

CASDK repo has two workflows for deployment.

* 2-pre-release.yaml - publish WebAPI container image to GitHub Packages
* dev_carbon-aware-api.yml - publish WebAPI to Azure Web Apps

They expect to run on original repo ( Green-Software-Foundation/carbon-aware-sdk ), however it would run on forked repo because they would also be triggered by pushing to `dev` branch. Thus we will see some errors on GHA as following.

* https://github.com/YaSuenag/carbon-aware-sdk/actions/runs/4862140346
* https://github.com/YaSuenag/carbon-aware-sdk/actions/runs/4862140351

It is noisy to work on forked repo, thus we need to skip them in forked repositories.

After this change, they are skipped as following:

* https://github.com/YaSuenag/carbon-aware-sdk/actions/runs/4890905942
* https://github.com/YaSuenag/carbon-aware-sdk/actions/runs/4890905936

## Changes

* 2-pre-release.yaml
* dev_carbon-aware-api.yml

## Checklist

- [ ] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [x] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?

No

## Is this a breaking change?

No

## Anything else?

I checked this change on my forked repo, but we need to pay attention to their behavior when some changes are pushed into `dev` on GSF CASDK repo. It is ok if they work without any errors.