### PR TITLE
Fix workflow error in 2-pre-release.yaml

### DIFF
--- a/.github/workflows/2-pre-release.yaml
+++ b/.github/workflows/2-pre-release.yaml
@@ -83,6 +83,8 @@ jobs:
 
           $remove_images = $ids -join ","
           "REMOVE_IMAGES=$remove_images" >> $env:GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
         shell: pwsh
       - name: Remove stale packages
         uses: actions/delete-package-versions@v4


### PR DESCRIPTION
# Pull Request

## Summary

Fix workflow error in 2-pre-release.yaml.

Since #339 , we see workflow error due to unset GH_TOKEN. https://github.com/Green-Software-Foundation/carbon-aware-sdk/actions/runs/4923635734/jobs/8795681332  
So I added it to the workflow. It works fine on my forked repo: https://github.com/YaSuenag/carbon-aware-sdk/actions/runs/4924388705/jobs/8797365487

## Changes

- 2-pre-release.yaml

## Checklist

- [ ] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [x] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?

No

## Is this a breaking change?

No