### PR TITLE
Install curl into WebAPI container

### DIFF
--- a/src/CarbonAware.WebApi/src/Dockerfile
+++ b/src/CarbonAware.WebApi/src/Dockerfile
@@ -13,6 +13,10 @@ RUN dotnet tool restore && \
 
 # Build runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:6.0
+# Install curl for health check
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl
+# Copy artifacts from build-env
 WORKDIR /app
 COPY --from=build-env /app/publish .
 ENTRYPOINT ["dotnet", "CarbonAware.WebApi.dll"]


### PR DESCRIPTION
## Summary

Install curl into WebAPI container for health check.

WebAPI provides endpoint for health check (/health), and we can use it for container health check (`--health-cmd` in `docker` / `podman`). However we cannot use any HTTP clients in WebAPI container because they are not installed.

According to [ASP.NET document](https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks?view=aspnetcore-6.0#docker-healthcheck) which is base image of WebAPI container, it does not provides `curl`, but we can install it. We can see the result of health check in below after this change:

```json
"Healthcheck": {
  "Status": "healthy",
  "FailingStreak": 0,
  "Log": [
    {
      "Start": "2023-05-27T12:28:38.1216648+09:00",
      "End": "2023-05-27T12:28:38.2329616+09:00",
      "ExitCode": 0,
      "Output": ""
    },
```

And also, we can use health check to suspend subsequent steps until service container is started in GitHub Workflow in below:

```yaml
jobs:
  generate-java-client:
    runs-on: ubuntu-latest
    services:
      webapi:
        image: ${{ inputs.image }}:${{ inputs.tag }}
        ports:
          - 8080:80
        options: >-
          --health-cmd "curl -sS http://localhost/health"
          --health-interval 3s
          --health-timeout 5s
          --health-retries 5
```

## Changes

- Dockerfile of WebAPI container

## Checklist

- [ ] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [x] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?

No

## Is this a breaking change?

No

## Anything else?

This change will be required to add workflows which generates any artifacts like Java client from WebAPI container. See https://github.com/Green-Software-Foundation/carbon-aware-sdk/issues/252#issuecomment-1482732796 for details.