### PR TITLE
Emissions-forecasts with ElectricityMaps will return server error 500

### DIFF
--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMaps/src/ElectricityMapsDataSource.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMaps/src/ElectricityMapsDataSource.cs
@@ -45,8 +45,8 @@ internal class ElectricityMapsDataSource : IForecastDataSource, IEmissionsDataSo
     {
         ForecastedCarbonIntensityData forecast;
         var geolocation = await this._locationSource.ToGeopositionLocationAsync(location);
-        if (geolocation.Latitude != null && geolocation.Latitude != null)
-            forecast = await this._electricityMapsClient.GetForecastedCarbonIntensityAsync (geolocation.Latitude.ToString() ?? "", geolocation.Longitude.ToString() ?? "");
+        if (geolocation.Latitude != null && geolocation.Longitude != null)
+            forecast = await this._electricityMapsClient.GetForecastedCarbonIntensityAsync (geolocation.LatitudeAsCultureInvariantString(), geolocation.LongitudeAsCultureInvariantString());
         else
         {
             forecast = await this._electricityMapsClient.GetForecastedCarbonIntensityAsync (geolocation.Name ?? "");


### PR DESCRIPTION
# Pull Request

Issue Number: #364

## Summary

ElectricityMaps forecast scenario will return server error 500.
Repro using CLI:  "emissions-forecasts -l westeurope -v"

public async Task<EmissionsForecast> GetCurrentCarbonIntensityForecastAsync(Location location) is causing the EM server to return 500. Reason is that the "." in geolocation.Latitude will be passed as "," 

## Changes

`public async Task<EmissionsForecast> GetCurrentCarbonIntensityForecastAsync(Location location)`

1) Fixing Input parameter validation for second condition to Longitude:

`if (geolocation.Latitude != null && geolocation.Longitude != null)`

2) Changing parameter parsing to use geolocation.LatitudeAsCultureInvariantString() and geolocation.LongitudeAsCultureInvariantString() to keep the correct formatting of the values.

`GetForecastedCarbonIntensityAsync(geolocation.LatitudeAsCultureInvariantString(), geolocation.LongitudeAsCultureInvariantString());`

## Checklist

- [ ] Local Tests Passing?
- [ ] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [x] This is not a breaking change. If it is, please describe it below.

## Is this a breaking change?

If yes, what workflow does this break?

> Please follow
> [GitHub's suggested syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
> to link Pull Requests to Issues via keywords

This PR Closes #364
