### PR TITLE
Fix CLI commands in quickstart.md 

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -96,7 +96,7 @@ Expected output:
 
 For example, to get emissions in the `eastus` and `uksouth` region between
 `2022-08-23 at 11:15am` and `2022-08-23 at 11:20am`, run:
-`dotnet run -l eastus,uksouth -t 2022-08-23T11:15 --toTime 2022-08-23T11:20`
+`dotnet run emissions -l eastus,uksouth -s 2022-08-23T11:15 -e 2022-08-23T11:20`
 
 Expected output:
 
@@ -147,7 +147,7 @@ hour window on the 23rd of August in the regions: `eastus`, `westus`,
 `westus3`,`uksouth`, run the command:
 
 ```bash
-dotnet run -l eastus,westus,westus3,uksouth -t 2022-08-23T00:00 --toTime 2022-08-23T23:59 --best
+dotnet run -l eastus,westus,westus3,uksouth -s 2022-08-23T00:00 -e 2022-08-23T23:59 --best
 ```
 
 Expected output:


### PR DESCRIPTION
# Pull Request

Issue Number: #370 

## Summary

Fixing args in commands shown in the quickstart.md document.

## Changes

- `dotnet run` needs to be followed by a command such as emissions, locations, or emissions-forecasts
- `-t` is now `-s`
- `--toTime` is now `-e`

## Checklist

- [ ] Local Tests Passing?
- [ ] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [x] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [ ] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?

If yes, what are the expected API Changes? Please link to an API-Comparison
workflow with the API Diff.

## Is this a breaking change?

If yes, what workflow does this break?

## Anything else?

Other comments, collaborators, etc.

> Please follow
> [GitHub's suggested syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
> to link Pull Requests to Issues via keywords

This PR Closes #370 
