### PR TITLE
EMFree data source should regard specified time range

### DIFF
--- a/src/CarbonAware.CLI/test/integrationTests/Commands/Emissions/EmissionsCommandTests.cs
+++ b/src/CarbonAware.CLI/test/integrationTests/Commands/Emissions/EmissionsCommandTests.cs
@@ -72,7 +72,7 @@ internal class EmissionsCommandTests : IntegrationTestingBase
         _dataSourceMocker.SetupDataMock(start, end, location);
 
         // Act
-        var exitCode = await InvokeCliAsync($"emissions -l {location} -s 2022-09-01T02:01:00Z -e 2022-09-01T02:04:00Z");
+        var exitCode = await InvokeCliAsync($"emissions -l {location} -s 2022-09-01T00:00:00Z -e 2022-09-01T00:04:00Z");
 
         // Assert
         Assert.AreEqual(0, exitCode);
@@ -117,7 +117,7 @@ internal class EmissionsCommandTests : IntegrationTestingBase
         _dataSourceMocker.SetupDataMock(start, end, location);
 
         // Act
-        var exitCode = await InvokeCliAsync($"emissions -l {location} -s 2022-09-01T02:01:00Z -e 2022-09-01T02:04:00Z -b");
+        var exitCode = await InvokeCliAsync($"emissions -l {location} -s 2022-09-01T00:00:00Z -e 2022-09-01T00:04:00Z -b");
 
         // Assert
         Assert.AreEqual(0, exitCode);

--- a/src/CarbonAware.CLI/test/integrationTests/Commands/EmissionsForecasts/EmissionsForecastsCommandTests.cs
+++ b/src/CarbonAware.CLI/test/integrationTests/Commands/EmissionsForecasts/EmissionsForecastsCommandTests.cs
@@ -71,8 +71,8 @@ internal class EmissionsForecastsCommandTests : IntegrationTestingBase
         var location = "eastus";
         var start = DateTimeOffset.UtcNow.AddMinutes(10);
         var end =  start.AddHours(5);
-        var dataStartAt = start.ToString("yyyy-MM-ddTHH:mm:ss");
-        var dataEndAt = end.ToString("yyyy-MM-ddTHH:mm:ss");
+        var dataStartAt = start.ToString("yyyy-MM-ddTHH:mm:ssZ");
+        var dataEndAt = end.ToString("yyyy-MM-ddTHH:mm:ssZ");
        
         _dataSourceMocker.SetupForecastMock();
         // Act

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMapsFree/src/ElectricityMapsFreeDataSource.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMapsFree/src/ElectricityMapsFreeDataSource.cs
@@ -87,8 +87,10 @@ internal class ElectricityMapsFreeDataSource : IEmissionsDataSource
         
         List<EmissionsData> EmissionsDataList = new List<EmissionsData>();
         var emissionDateTime = gridEmissionData.Data.Datetime;
-        var shouldReturn = true;
-        if (emissionDateTime != null && periodStartTime < periodEndTime)
+
+        // periodStartTime should be less than current date time because this method should not handle forecast data.
+        var shouldReturn = periodStartTime <= DateTimeOffset.UtcNow;
+        if (shouldReturn && emissionDateTime != null && periodStartTime < periodEndTime)
         {
             // periodEndTime would be set periodStartTime in EmissionHandler if it is not specified.
             // So we can assume we should return the most recent data if they equal.

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMapsFree/src/ElectricityMapsFreeDataSource.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMapsFree/src/ElectricityMapsFreeDataSource.cs
@@ -86,15 +86,27 @@ internal class ElectricityMapsFreeDataSource : IEmissionsDataSource
         }
         
         List<EmissionsData> EmissionsDataList = new List<EmissionsData>();
-
-        var emissionData = new EmissionsData()
+        var emissionDateTime = gridEmissionData.Data.Datetime;
+        var shouldReturn = true;
+        if (emissionDateTime != null && periodStartTime < periodEndTime)
         {
-            Location = location.Name ?? "",
-            Time = gridEmissionData.Data.Datetime ?? new DateTimeOffset(),
-            Rating = gridEmissionData.Data.CarbonIntensity ?? 0.0,
-            Duration = new TimeSpan(0, 0, 0)
-        };
-        EmissionsDataList.Add(emissionData);
+            // periodEndTime would be set periodStartTime in EmissionHandler if it is not specified.
+            // So we can assume we should return the most recent data if they equal.
+            // If not, we should return the data after checking it is within specified time range.
+            shouldReturn = periodStartTime <= emissionDateTime && emissionDateTime < periodEndTime;
+        }
+
+        if (shouldReturn)
+        {
+            var emissionData = new EmissionsData()
+            {
+                Location = location.Name ?? "",
+                Time = emissionDateTime ?? new DateTimeOffset(),
+                Rating = gridEmissionData.Data.CarbonIntensity ?? 0.0,
+                Duration = new TimeSpan(0, 0, 0)
+            };
+            EmissionsDataList.Add(emissionData);
+        }
 
         return EmissionsDataList;
     }

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMapsFree/test/ElectricityMapsFreeDataSourceTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMapsFree/test/ElectricityMapsFreeDataSourceTests.cs
@@ -36,8 +36,9 @@ public class ElectricityMapsFreeDataSourceTests
         _dataSource = new ElectricityMapsFreeDataSource(_logger.Object, _ElectricityMapsFreeClient.Object, _locationSource.Object);
     }
 
-    [Test]
-    public async Task GetCarbonIntensity_ReturnsResultsWhenRecordsFound()
+    [TestCase(false, TestName = "GetCarbonIntensity_ReturnsResultsWhenRecordsFound without emission date time")]
+    [TestCase(true, TestName = "GetCarbonIntensity_ReturnsResultsWhenRecordsFound with emission date time")]
+    public async Task GetCarbonIntensity_ReturnsResultsWhenRecordsFound(bool withEmissionDateTime)
     {
         var startDate = DateTimeOffset.UtcNow.AddHours(-10);
         var endDate = startDate.AddHours(1);
@@ -49,6 +50,7 @@ public class ElectricityMapsFreeDataSourceTests
         {
             Data = new Data()
             {
+                Datetime = withEmissionDateTime ? startDate.AddMinutes(30) : null,
                 CarbonIntensity = expectedCarbonIntensity,
             }
         };
@@ -71,8 +73,9 @@ public class ElectricityMapsFreeDataSourceTests
         this._locationSource.Verify(l => l.ToGeopositionLocationAsync(_defaultLocation));
     }
 
-    [Test]
-    public async Task GetCarbonIntensity_UseRegionNameWhenCoordinatesNotAvailable()
+    [TestCase(false, TestName = "GetCarbonIntensity_UseRegionNameWhenCoordinatesNotAvailable without emission date time")]
+    [TestCase(true, TestName = "GetCarbonIntensity_UseRegionNameWhenCoordinatesNotAvailable with emission date time")]
+    public async Task GetCarbonIntensity_UseRegionNameWhenCoordinatesNotAvailable(bool withEmissionDateTime)
     {
         var startDate = new DateTimeOffset(2022, 4, 18, 12, 32, 42, TimeSpan.FromHours(-6));
         var endDate = startDate.AddMinutes(1);
@@ -84,6 +87,7 @@ public class ElectricityMapsFreeDataSourceTests
         {
             Data = new Data()
             {
+                Datetime = withEmissionDateTime ? startDate.AddSeconds(30) : null,
                 CarbonIntensity = expectedCarbonIntensity,
             }
         };


### PR DESCRIPTION
# Pull Request

Issue Number: N/A

## Summary

Make ElectricityMapsFree data source aware of specifying time range. 
Currently WebAPI would return data even if it is out of time range which is specified in below:

```
Attempt to retrieve data to 2023-09-03T00:00:00Z from 2023-09-02T00:00:00Z

$ curl -s 'http://localhost:8082/emissions/bylocation?location=japaneast&startTime=2023-09-02T00%3A00%3A00Z&endTime=2023-09-03T00%3A00%3A00Z' | jq
[
  {
    "location": "japaneast",
    "time": "2023-09-04T00:00:00+00:00",  <- out of range!
    "rating": 530,
    "duration": "00:00:00"
  }
]
```

It should be returned empty (HTTP 204 or empty JSON array) or an error in this case.

## Changes

- src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMapsFree/src/ElectricityMapsFreeDataSource.cs
    - Key point of this PR. [CO2Signal API](https://docs.co2signal.com/#routes) does not have any parameters for time range, so EMFree data source filters before returning data when time range is specified.
- src/CarbonAware.CLI/test/integrationTests/Commands/Emissions/EmissionsCommandTests.cs
    - Only one test data would be generated in EMFree mock datasource, and it has emission data time equivalent with start time. Thus we need to cover it in specified time range. 
    - In other case (WattTime, EM, JSON), multiple test data would be generated each 5 minutes. So we need to tweak time range within 5 minutes because number of response data would be checked by subsequent assertion.
- src/CarbonAware.CLI/test/integrationTests/Commands/EmissionsForecasts/EmissionsForecastsCommandTests.cs
    - This test would fail in some timezone (Japan at least). So add `Z` to time string because time is treated as UTC. (Let me know if this change should be happened in other issue)
- src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMapsFree/test/ElectricityMapsFreeDataSourceTests.cs
    - Run tests both with/without time range

## Checklist

- [x] Local Tests Passing?
- [ ] CICD and Pipeline Tests Passing?
- [x] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [x] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?

No

## Is this a breaking change?

EMFree data source would not return any data when it does not exist within specified time range. But it is expected behavior I think.