### PR TITLE
Fix: verify-azure-function-with-packages #383

### DIFF
--- a/.github/workflows/verify-azure-function-with-packages.yaml
+++ b/.github/workflows/verify-azure-function-with-packages.yaml
@@ -26,10 +26,11 @@ jobs:
         continue-on-error: true
         run: docker rm -f ${{ env.CONTAINER_RUNTIME_NAME }}
 
+      # Build and tag final image, remove dangling images only if there are any
       - name: Docker Target Final
         run: |
           docker build --no-cache . -f ${{ env.DOCKERFILE_PATH }} -t ${{ env.CONTAINER_IMAGE_NAME }}
-          docker rmi -f $(docker images -f "dangling=true" -q)
+          docker images -qf dangling=true | xargs --no-run-if-empty docker rmi
 
       - name: Docker Run Container
         run: docker run -d --name ${{ env.CONTAINER_RUNTIME_NAME }} -p 8080:80 ${{ env.CONTAINER_IMAGE_NAME }}


### PR DESCRIPTION
# Pull Request

Issue Number: #383 

## Summary

Replace current method of removing dangling images to do so only if there are any (and avoid running `docker rmi -f` with no params).

## Checklist

- [ ] Local Tests Passing?
- [ ] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [ ] This is not a breaking change. If it is, please describe it below.

## Anything else?

Other comments, collaborators, etc.

> Please follow
> [GitHub's suggested syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
> to link Pull Requests to Issues via keywords

This PR Closes #383
