### PR TITLE
ADR Proposal: Throws exception when future datetime is passed to current/historical APIs

### DIFF
--- a/docs/architecture/decisions/0016-throws-exception-from-historical-ep.md
+++ b/docs/architecture/decisions/0016-throws-exception-from-historical-ep.md
@@ -1,0 +1,33 @@
+
+# 0016. Throws exception when future datetime is passed to current/historical APIs
+
+## Status
+
+Proposed
+
+## Context
+
+Current/historical APIs (e.g. /bylocation WebAPI endpoint) shouldn't accept future datetime because they are not for forecast data. So it should return an error when future datetime is passed.
+
+Currently (v1.1 at least) current/historical APIs return empty list even if future datetime is passed. So we cannot aware it is invalid arguments when we call these APIs with future datetime.
+
+## Decision
+
+In C# code, throw [ArgumentOutOfRangeException](https://learn.microsoft.com/en-us/dotnet/api/system.argumentoutofrangeexception) when future datetime is passed to current/historical APIs.
+
+In WebAPI, returns HTTP 400 (Bad request) to client when catches `ArgumentOutOfRangeException`.
+
+### Affected WebAPI endpoints
+
+* /bylocations/best
+* /bylocations
+* /bylocation
+* /average-carbon-intensity
+
+### Affected C# methods
+
+* Implementations of `IEmissionsDataSource.GetCarbonIntensityAsync()`
+
+## Green Impact  
+
+Neutral


### PR DESCRIPTION
# Pull Request

#396 

## Summary

Propose to throw exception / return HTTP error status when future datetime is passed to current/historical APIs.

## Changes

Add ADR about this topic. See ADR-0016 document in this PR for details.

## Checklist

- [ ] Local Tests Passing?
- [ ] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [ ] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?

No

## Is this a breaking change?

No