### PR TITLE
Add cache functionality for emissions data

### DIFF
--- a/casdk-docs/docs/tutorial-extras/configuration.md
+++ b/casdk-docs/docs/tutorial-extras/configuration.md
@@ -19,6 +19,7 @@
     - [ElectricityMapsFree Configuration](#electricitymapsfree-configuration)
       - [API Token](#api-token)
       - [BaseUrl](#baseurl)
+  - [Cache](#cache)
   - [CarbonAwareVars](#carbonawarevars)
     - [Tracing and Monitoring Configuration](#tracing-and-monitoring-configuration)
     - [Verbosity](#verbosity)
@@ -326,6 +327,29 @@ The ElectricityMapsFree token you receive with your account.
 The url to use when connecting to ElectricityMapsFree. Defaults to
 "https://api.co2signal.com/v1/" but can be overridden in the config if needed
 (such as to enable integration testing scenarios).
+
+## Cache
+
+Frequent access to data sources could cause problems such as performance trouble
+or exceed rate limit. To avoid them, you can configure data cache like this:
+
+```json
+{
+  "EmissionsDataCache": {
+    "Enabled": true,
+    "ExpirationMin": 30
+  }
+}
+```
+
+The behavior of current cache implementation:
+* Only emissions data are cached
+  * Forecast data are not stored
+* The result of the latest query to data sources is cached
+* Use cache rather than data sources if even one datum in cache match with the query
+  * Even though more data in data sources would be matched, they are not retrieved
+* Cached data are stored in memory
+  * They are cleard when the process of the SDK is down
 
 ## CarbonAwareVars
 

--- a/src/CarbonAware/src/Configuration/EmissionsDataCacheConfiguration.cs
+++ b/src/CarbonAware/src/Configuration/EmissionsDataCacheConfiguration.cs
@@ -12,9 +12,9 @@ internal class EmissionsDataCacheConfiguration
 
     public void AssertValid()
     {
-        if(ExpirationMin < 0)
+        if(ExpirationMin <= 0)
         {
-            throw new ArgumentException($"Expiration period for data cache value must be greater than or equal 0.");
+            throw new ArgumentException($"Expiration period for data cache value must be greater than 0.");
         }
     }
 }

--- a/src/CarbonAware/src/Configuration/EmissionsDataCacheConfiguration.cs
+++ b/src/CarbonAware/src/Configuration/EmissionsDataCacheConfiguration.cs
@@ -1,0 +1,20 @@
+using Microsoft.Extensions.Configuration;
+
+namespace CarbonAware.Configuration;
+
+internal class EmissionsDataCacheConfiguration
+{
+    public const string Key = "EmissionsDataCache";
+
+    public bool Enabled { get; set; }
+
+    public int ExpirationMin { get; set; }
+
+    public void AssertValid()
+    {
+        if(ExpirationMin < 0)
+        {
+            throw new ArgumentException($"Expiration period for data cache value must be greater than or equal 0.");
+        }
+    }
+}

--- a/src/CarbonAware/src/Configuration/EmissionsDataCacheConfigurationExtensions.cs
+++ b/src/CarbonAware/src/Configuration/EmissionsDataCacheConfigurationExtensions.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.Configuration;
+
+namespace CarbonAware.Configuration;
+
+internal static class EmissionsDataCacheConfigurationExtensions
+{
+    public static EmissionsDataCacheConfiguration EmissionsDataCache(this IConfiguration configuration)
+    {
+        var dataCache = configuration.GetSection(EmissionsDataCacheConfiguration.Key).Get<EmissionsDataCacheConfiguration>() ?? new EmissionsDataCacheConfiguration();
+        dataCache.AssertValid();
+
+        return dataCache;
+    }
+}

--- a/src/CarbonAware/src/Proxies/Cache/LatestEmissionsCache.cs
+++ b/src/CarbonAware/src/Proxies/Cache/LatestEmissionsCache.cs
@@ -1,0 +1,150 @@
+using CarbonAware.Configuration;
+using CarbonAware.Interfaces;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Reflection;
+
+namespace CarbonAware.Proxies.Cache;
+
+/// <summary>
+/// A proxy class for <c>IEmissionsDataSource</c> to cache <c>EmissionsData</c>.
+/// This class caches data which is queried latestly for each <c>Location</c>.
+/// The cached value are used if it satisfies all of the conditions listed below.
+/// <list type="bullet">
+/// <item>
+/// <description>it is not exceeded the expiration period</description>
+/// </item>
+/// <item>
+/// <description>the name of the location is match with the query</description>
+/// </item>
+/// <item>
+/// <description>the time is match with the query</description>
+/// </item>
+/// </list>
+/// </summary>
+/// <typeparam name="T">The target class of the proxy</typeparam>
+class LatestEmissionsCache<T> : DispatchProxy where T : class, IEmissionsDataSource
+{
+ 
+    private IEmissionsDataSource? _target { get; set; }
+
+    readonly private ConcurrentDictionary<string, (DateTimeOffset, IEnumerable<EmissionsData>)> _cache =
+        new ConcurrentDictionary<string, (DateTimeOffset, IEnumerable<EmissionsData>)>();
+
+    private EmissionsDataCacheConfiguration? _config { get; set; }
+
+    public static T? CreateProxy(T target, EmissionsDataCacheConfiguration config)
+    {
+        var proxy = Create<T, LatestEmissionsCache<T>>() as LatestEmissionsCache<T>;
+        proxy!._target = target;
+        proxy._config = config;
+        return proxy as T;
+    }
+
+    protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+    {
+        if(targetMethod!.Name.Equals("GetCarbonIntensityAsync") && args![0]!.GetType() == typeof(Location))
+        {
+            var location = (Location?)args[0];
+            var start = (DateTimeOffset)args[1]!;
+            var end = (DateTimeOffset)args[2]!;
+            return ProxyGetCarbonIntensityAsync(targetMethod, location!, start, end);
+        } else if(targetMethod.Name.Equals("GetCarbonIntensityAsync") && args![0]!.GetType().GetInterfaces().Contains(typeof(IEnumerable<Location>)))
+        {
+            var locations = (IEnumerable<Location>?)args[0];
+            var start = (DateTimeOffset)args[1]!;
+            var end = (DateTimeOffset)args[2]!;
+            return ProxyGetCarbonIntensityAsync(targetMethod, locations!, start, end);
+        }
+        return targetMethod.Invoke(_target, args);
+    }
+
+    private Task<IEnumerable<EmissionsData>> ProxyGetCarbonIntensityAsync(MethodInfo? original, Location location, DateTimeOffset periodStartTime, DateTimeOffset periodEndTime)
+    {
+        var cachedData = GetCachedData(location, periodStartTime, periodEndTime);
+        if(cachedData.Count() != 0)
+        {
+            return Task.FromResult(cachedData);
+        }
+
+        object[] args = {location, periodStartTime, periodEndTime};
+        var resultFromOriginal = (Task<IEnumerable<EmissionsData>>?)original!.Invoke(_target, args);
+
+        if(string.IsNullOrEmpty(location.Name))
+        {
+            return resultFromOriginal!;
+        } else 
+        {
+            var expiration = DateTimeOffset.UtcNow.AddMinutes(_config!.ExpirationMin);
+            var result = resultFromOriginal!.ContinueWith
+            (
+                c =>
+                {
+                    _cache.AddOrUpdate(location.Name, (expiration, c.Result), (_, _) => (expiration, c.Result));
+                    return c.Result;
+                }
+            );
+            return result;
+        }
+    }
+
+    private Task<IEnumerable<EmissionsData>> ProxyGetCarbonIntensityAsync(MethodInfo? original, IEnumerable<Location> locations, DateTimeOffset periodStartTime, DateTimeOffset periodEndTime)
+    {
+        var cachedData = Enumerable.Empty<EmissionsData>();
+        var useCacheFor = Enumerable.Empty<string?>();
+        foreach (var location in locations)
+        {
+            var cachedDataForLocation = GetCachedData(location, periodStartTime, periodEndTime);
+            if(cachedDataForLocation.Count() != 0)
+            {
+                cachedData = cachedData.Union(cachedDataForLocation);
+                useCacheFor = useCacheFor.Append(location.Name);
+            }
+        }
+
+        var locationsForQuery = locations.Where(l => string.IsNullOrEmpty(l.Name) || !useCacheFor.Contains(l.Name));
+        if(locationsForQuery.Count() == 0){
+            return Task.FromResult(cachedData);
+        }
+
+        object[] args = {locationsForQuery, periodStartTime, periodEndTime};
+        var resultFromOriginal = (Task<IEnumerable<EmissionsData>>?)original!.Invoke(_target, args);
+        
+        var expiration = DateTimeOffset.UtcNow.AddMinutes(_config!.ExpirationMin);
+        var result = resultFromOriginal!.ContinueWith
+            (
+                c =>
+                {
+                    foreach (var location in locationsForQuery)
+                    {
+                        if(!string.IsNullOrEmpty(location.Name))
+                        {
+                            var data = c.Result.Where(d => d.Location.Equals(location.Name));
+                            _cache.AddOrUpdate(location.Name, (expiration, data), (_, _) => (expiration, data));
+                        }
+                    }
+                    return c.Result.Union(cachedData);
+                }
+            );
+            return result;
+    }
+
+    private IEnumerable<EmissionsData> GetCachedData(Location location, DateTimeOffset periodStartTime, DateTimeOffset periodEndTime)
+    {
+        if(!string.IsNullOrEmpty(location.Name) && _cache.ContainsKey(location.Name))
+        {
+            var cachedValue = _cache.GetValueOrDefault(location.Name);
+
+            // check expiration
+            if(cachedValue.Item1.CompareTo(DateTimeOffset.UtcNow) > 0)
+            {
+                IEnumerable<EmissionsData> emissions = cachedValue.Item2.Where(d => d.TimeBetween(periodStartTime, periodEndTime));
+                if(emissions.Count() != 0)
+                {
+                    return emissions;
+                }
+            }
+        }
+        return Enumerable.Empty<EmissionsData>();
+    }
+}

--- a/src/CarbonAware/test/CarbonAware.Tests.csproj
+++ b/src/CarbonAware/test/CarbonAware.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Moq" />
     <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/CarbonAware/test/Configuration/EmissionsDataCacheConfigurationTests.cs
+++ b/src/CarbonAware/test/Configuration/EmissionsDataCacheConfigurationTests.cs
@@ -5,7 +5,6 @@ namespace CarbonAware.Tests.Configuration;
 class EmissionsDataCacheConfigurationTests
 {
     [TestCase(10, TestName = "AssertValid: ExpirationMin greater than 0")]
-    [TestCase(0, TestName = "AssertValid: ExpirationMin equals to 0")]
     public void AssertValid_ExpirationMinGreaterThanOrEqualsToZero_DoesNotThrowException(int expirationMin)
     {
         EmissionsDataCacheConfiguration emissionsDataCacheConfig = new EmissionsDataCacheConfiguration()
@@ -17,6 +16,7 @@ class EmissionsDataCacheConfigurationTests
         Assert.DoesNotThrow(() => emissionsDataCacheConfig.AssertValid());
     }
 
+    [TestCase(0, TestName = "AssertValid: ExpirationMin equals to 0")]
     [TestCase(-10, TestName = "AssertValid: ExpirationMin less than 0")]
     public void AssertValid_ExpirationMinLessThanZero_ThrowException(int expirationMin)
     {

--- a/src/CarbonAware/test/Configuration/EmissionsDataCacheConfigurationTests.cs
+++ b/src/CarbonAware/test/Configuration/EmissionsDataCacheConfigurationTests.cs
@@ -1,0 +1,31 @@
+using CarbonAware.Configuration;
+
+namespace CarbonAware.Tests.Configuration;
+
+class EmissionsDataCacheConfigurationTests
+{
+    [TestCase(10, TestName = "AssertValid: ExpirationMin greater than 0")]
+    [TestCase(0, TestName = "AssertValid: ExpirationMin equals to 0")]
+    public void AssertValid_ExpirationMinGreaterThanOrEqualsToZero_DoesNotThrowException(int expirationMin)
+    {
+        EmissionsDataCacheConfiguration emissionsDataCacheConfig = new EmissionsDataCacheConfiguration()
+        {
+            Enabled = true,
+            ExpirationMin = expirationMin
+        };
+        
+        Assert.DoesNotThrow(() => emissionsDataCacheConfig.AssertValid());
+    }
+
+    [TestCase(-10, TestName = "AssertValid: ExpirationMin less than 0")]
+    public void AssertValid_ExpirationMinLessThanZero_ThrowException(int expirationMin)
+    {
+        EmissionsDataCacheConfiguration emissionsDataCacheConfig = new EmissionsDataCacheConfiguration()
+        {
+            Enabled = true,
+            ExpirationMin = expirationMin
+        };
+        
+        Assert.Throws<ArgumentException>(() => emissionsDataCacheConfig.AssertValid());
+    }
+}

--- a/src/CarbonAware/test/Proxy/Cache/LatestEmissionsCacheTests.cs
+++ b/src/CarbonAware/test/Proxy/Cache/LatestEmissionsCacheTests.cs
@@ -1,0 +1,231 @@
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using CarbonAware.Configuration;
+using CarbonAware.Interfaces;
+using CarbonAware.Model;
+using Moq;
+
+namespace CarbonAware.Proxies.Cache;
+
+class LatestEmissionsCacheTests
+{
+
+    Mock<IEmissionsDataSource>? _mock;
+
+    IEmissionsDataSource? _dataSource;
+
+    IDictionary<string, DateTimeOffset>? _dateTimes;
+
+    IDictionary<string, EmissionsData>? _emissions;
+
+    IDictionary<string, Location>? _locations;
+
+    [Test]
+    public void GetCarbonIntensityAsync_ForSingleLocation_UseCachedDataForSameQuery()
+    {
+        var config = new EmissionsDataCacheConfiguration();
+        config.Enabled = true;
+        config.ExpirationMin = 10;
+
+        var dataSource = LatestEmissionsCache<IEmissionsDataSource>.CreateProxy(_dataSource!, config);
+        var resultFromDataSource = dataSource!.GetCarbonIntensityAsync(_locations!["eastus"], _dateTimes!["firstDay"], _dateTimes["secondDay"]).Result;
+        var resultFromCache = dataSource!.GetCarbonIntensityAsync(_locations!["eastus"], _dateTimes!["firstDay"], _dateTimes["secondDay"]).Result;
+
+        // The results are same
+        Assert.AreEqual(resultFromDataSource, resultFromCache);
+        // The access to the data source occurs just once
+        _mock!.Verify(ds => ds.GetCarbonIntensityAsync(_locations!["eastus"], _dateTimes!["firstDay"], _dateTimes["secondDay"]), Moq.Times.Once);
+    }
+
+    [Test]
+    public void GetCarbonIntensityAsync_ForSingleLocation_UsePartOfCachedData()
+    {
+        var config = new EmissionsDataCacheConfiguration();
+        config.Enabled = true;
+        config.ExpirationMin = 10;
+
+        var dataSource = LatestEmissionsCache<IEmissionsDataSource>.CreateProxy(_dataSource!, config);
+        var resultFromDataSource = dataSource!.GetCarbonIntensityAsync(_locations!["eastus"], _dateTimes!["firstDay"], _dateTimes["thirdDay"]).Result;
+        var resultFromCache = dataSource!.GetCarbonIntensityAsync(_locations!["eastus"], _dateTimes!["firstDay"], _dateTimes["secondDay"]).Result;
+
+        // The result for the second query is a part of the first one
+        Assert.AreEqual(resultFromDataSource.Count(), 2);
+        Assert.AreEqual(resultFromCache.Count(), 1);
+        // The second query does not access to tha data source
+        _mock!.Verify(ds => ds.GetCarbonIntensityAsync(_locations!["eastus"], _dateTimes!["firstDay"], _dateTimes["secondDay"]), Moq.Times.Never);
+    }
+
+    [Test]
+    public void GetCarbonIntensityAsync_ForSingleLocation_AccessToDataSourceIfCachedDataIsNotMached()
+    {
+        var config = new EmissionsDataCacheConfiguration();
+        config.Enabled = true;
+        config.ExpirationMin = 10;
+
+        var dataSource = LatestEmissionsCache<IEmissionsDataSource>.CreateProxy(_dataSource!, config);
+        var resultOfFirst = dataSource!.GetCarbonIntensityAsync(_locations!["eastus"], _dateTimes!["firstDay"], _dateTimes["secondDay"]).Result;
+        var resultOfSecond = dataSource!.GetCarbonIntensityAsync(_locations!["eastus"], _dateTimes!["secondDay"], _dateTimes["thirdDay"]).Result;
+
+        Assert.Contains(_emissions!["eastus-firstDay"], resultOfFirst.ToList());
+        Assert.Contains(_emissions["eastus-secondDay"], resultOfSecond.ToList());
+        // Both queries access to tha data source
+        _mock!.Verify(ds => ds.GetCarbonIntensityAsync(_locations!["eastus"], _dateTimes!["firstDay"], _dateTimes["secondDay"]), Moq.Times.Once);
+        _mock!.Verify(ds => ds.GetCarbonIntensityAsync(_locations!["eastus"], _dateTimes!["secondDay"], _dateTimes["thirdDay"]), Moq.Times.Once);
+    }
+
+    [Test]
+    public void GetCarbonIntensityAsync_ForSingleLocation_AccessToDataSourceIfLocationNameIsEmpty()
+    {
+        var config = new EmissionsDataCacheConfiguration();
+        config.Enabled = true;
+        config.ExpirationMin = 10;
+
+        var dataSource = LatestEmissionsCache<IEmissionsDataSource>.CreateProxy(_dataSource!, config);
+        var resultOfFirst = dataSource!.GetCarbonIntensityAsync(_locations!["coordinate"], _dateTimes!["firstDay"], _dateTimes["secondDay"]).Result;
+        var resultOfSecond = dataSource!.GetCarbonIntensityAsync(_locations!["coordinate"], _dateTimes!["firstDay"], _dateTimes["secondDay"]).Result;
+
+        Assert.AreEqual(resultOfFirst, resultOfSecond);
+        // Both queries access to tha data source
+        _mock!.Verify(ds => ds.GetCarbonIntensityAsync(_locations!["coordinate"], _dateTimes!["firstDay"], _dateTimes["secondDay"]), Moq.Times.Exactly(2));
+    }
+
+    [Test]
+    public void GetCarbonIntensityAsync_ForMultiLocation_UseCachedDataForSameQuery()
+    {
+        var config = new EmissionsDataCacheConfiguration();
+        config.Enabled = true;
+        config.ExpirationMin = 10;
+
+        var dataSource = LatestEmissionsCache<IEmissionsDataSource>.CreateProxy(_dataSource!, config);
+        var resultFromDataSource = dataSource!.GetCarbonIntensityAsync(new List<Location>{_locations!["eastus"], _locations["westus"]}, _dateTimes!["firstDay"], _dateTimes["secondDay"]).Result;
+        var resultFromCache = dataSource!.GetCarbonIntensityAsync(new List<Location>{_locations!["eastus"], _locations["westus"]}, _dateTimes!["firstDay"], _dateTimes["secondDay"]).Result;
+
+        // The results are same
+        Assert.AreEqual(resultFromDataSource, resultFromCache);
+        // The access to the data source occurs just once
+        _mock!.Verify(ds => ds.GetCarbonIntensityAsync(new List<Location>{_locations!["eastus"], _locations["westus"]}, _dateTimes!["firstDay"], _dateTimes["secondDay"]), Moq.Times.Once);
+    }
+
+    [Test]
+    public void GetCarbonIntensityAsync_ForMultiLocation_UsePartOfCachedData()
+    {
+        var config = new EmissionsDataCacheConfiguration();
+        config.Enabled = true;
+        config.ExpirationMin = 10;
+
+        var dataSource = LatestEmissionsCache<IEmissionsDataSource>.CreateProxy(_dataSource!, config);
+        var resultFromDataSource = dataSource!.GetCarbonIntensityAsync(new List<Location>{_locations!["eastus"], _locations["westus"]}, _dateTimes!["firstDay"], _dateTimes["secondDay"]).Result;
+        var resultFromCache = dataSource!.GetCarbonIntensityAsync(new List<Location>{_locations!["eastus"]}, _dateTimes!["firstDay"], _dateTimes["secondDay"]).Result;
+
+        // The result for the second query is a part of the first one
+        Assert.AreEqual(resultFromDataSource.Count(), 2);
+        Assert.AreEqual(resultFromCache.Count(), 1);
+        // The access to the data source occurs just once
+        _mock!.Verify(ds => ds.GetCarbonIntensityAsync(new List<Location>{_locations!["eastus"]}, _dateTimes!["firstDay"], _dateTimes["secondDay"]), Moq.Times.Never);
+    }
+
+    [Test]
+    public void GetCarbonIntensityAsync_ForMultiLocation_UsePartOfCachedData2()
+    {
+        var config = new EmissionsDataCacheConfiguration();
+        config.Enabled = true;
+        config.ExpirationMin = 10;
+
+        var dataSource = LatestEmissionsCache<IEmissionsDataSource>.CreateProxy(_dataSource!, config);
+        var resultForFirst = dataSource!.GetCarbonIntensityAsync(new List<Location>{_locations!["eastus"]}, _dateTimes!["firstDay"], _dateTimes["secondDay"]).Result;
+        var resultForSecond = dataSource!.GetCarbonIntensityAsync(new List<Location>{_locations!["eastus"], _locations["westus"]}, _dateTimes!["firstDay"], _dateTimes["secondDay"]).Result;
+
+        Assert.AreEqual(resultForFirst.Count(), 1);
+        Assert.AreEqual(resultForSecond.Count(), 2);
+        // the first query
+        _mock!.Verify(ds => ds.GetCarbonIntensityAsync(new List<Location>{_locations!["eastus"]}, _dateTimes!["firstDay"], _dateTimes["secondDay"]), Moq.Times.Once);
+        // the second query does not contain "eastus" because the data for "eastus" have been already cached
+        _mock!.Verify(ds => ds.GetCarbonIntensityAsync(new List<Location>{_locations!["westus"]}, _dateTimes!["firstDay"], _dateTimes["secondDay"]), Moq.Times.Once);
+    }
+
+    [SetUp]
+    public void Setup()
+    {
+        _mock!.Invocations.Clear();
+    }
+
+    [OneTimeSetUp]
+    public void SetupDataAndMock()
+    {
+        // Crate test data
+        _dateTimes = new Dictionary<string, DateTimeOffset>
+        {
+            {"firstDay", new DateTimeOffset(2021, 11, 16, 0, 0, 0, TimeSpan.Zero)},
+            {"secondDay", new DateTimeOffset(2021, 11, 17, 0, 0, 0, TimeSpan.Zero)},
+            {"thirdDay", new DateTimeOffset(2021, 11, 18, 0, 0, 0, TimeSpan.Zero)}
+        };
+
+        var location1 = new Location();
+        location1.Name = "eastus";
+        var location2 = new Location();
+        location2.Name = "westus";
+        var location3 = new Location();
+        location3.Latitude = 0;
+        location3.Longitude = 0;
+        _locations = new Dictionary<string, Location>
+        {
+            {"eastus", location1},
+            {"westus", location2},
+            {"coordinate", location3}
+        };
+
+        var emissions1 = new EmissionsData();
+        emissions1.Location = "eastus";
+        emissions1.Time = new DateTimeOffset(2021, 11, 16, 0, 55, 0, TimeSpan.Zero);
+        var emissions2 = new EmissionsData();
+        emissions2.Location = "eastus";
+        emissions2.Time = new DateTimeOffset(2021, 11, 17, 0, 55, 0, TimeSpan.Zero);
+        var emissions3 = new EmissionsData();
+        emissions3.Location = "westus";
+        emissions3.Time = new DateTimeOffset(2021, 11, 16, 0, 55, 0, TimeSpan.Zero);
+        var emissions4 = new EmissionsData();
+        emissions4.Location = "";
+        emissions4.Time = new DateTimeOffset(2021, 11, 16, 0, 55, 0, TimeSpan.Zero);
+        _emissions = new Dictionary<string, EmissionsData> 
+        {
+            {"eastus-firstDay", emissions1}, 
+            {"eastus-secondDay", emissions2},
+            {"westus-firstDay", emissions3},
+            {"coordinate-firstDay", emissions4}
+        };
+
+        // setup a mock
+        _mock = new Mock<IEmissionsDataSource>();
+
+        // setup for GetCarbonIntensityAsync(Location, DateTimeOffset, DateTimeOffset)
+        _mock.Setup(ds => 
+            ds.GetCarbonIntensityAsync(_locations["eastus"], _dateTimes["firstDay"], _dateTimes["secondDay"]))
+            .Returns(Task.FromResult((IEnumerable<EmissionsData>)new List<EmissionsData>{_emissions["eastus-firstDay"]}));
+        _mock.Setup(ds => 
+            ds.GetCarbonIntensityAsync(_locations["eastus"], _dateTimes["secondDay"], _dateTimes["thirdDay"]))
+            .Returns(Task.FromResult((IEnumerable<EmissionsData>)new List<EmissionsData>{_emissions["eastus-secondDay"]}));
+        _mock.Setup(ds => 
+            ds.GetCarbonIntensityAsync(_locations["eastus"], _dateTimes["firstDay"], _dateTimes["thirdDay"]))
+            .Returns(Task.FromResult((IEnumerable<EmissionsData>)new List<EmissionsData>{_emissions["eastus-firstDay"], _emissions["eastus-secondDay"]}));
+        _mock.Setup(ds => 
+            ds.GetCarbonIntensityAsync(_locations["westus"], _dateTimes["firstDay"], _dateTimes["secondDay"]))
+            .Returns(Task.FromResult((IEnumerable<EmissionsData>)new List<EmissionsData>{_emissions["westus-firstDay"]}));
+        _mock.Setup(ds => 
+            ds.GetCarbonIntensityAsync(_locations["coordinate"], _dateTimes["firstDay"], _dateTimes["secondDay"]))
+            .Returns(Task.FromResult((IEnumerable<EmissionsData>)new List<EmissionsData>{_emissions["coordinate-firstDay"]}));
+
+        // setup for GetCarbonIntensityAsync(IEnumerable<Location>, DateTimeOffset, DateTimeOffset)
+        _mock.Setup(ds => 
+            ds.GetCarbonIntensityAsync(new List<Location>{_locations["eastus"], _locations["westus"]}, _dateTimes["firstDay"], _dateTimes["secondDay"]))
+            .Returns(Task.FromResult((IEnumerable<EmissionsData>)new List<EmissionsData>{_emissions["eastus-firstDay"], _emissions["westus-firstDay"]}));
+        _mock.Setup(ds => 
+            ds.GetCarbonIntensityAsync(new List<Location>{_locations["eastus"]}, _dateTimes["firstDay"], _dateTimes["secondDay"]))
+            .Returns(Task.FromResult((IEnumerable<EmissionsData>)new List<EmissionsData>{_emissions["eastus-firstDay"]}));
+        _mock.Setup(ds => 
+            ds.GetCarbonIntensityAsync(new List<Location>{_locations["westus"]}, _dateTimes["firstDay"], _dateTimes["secondDay"]))
+            .Returns(Task.FromResult((IEnumerable<EmissionsData>)new List<EmissionsData>{_emissions["westus-firstDay"]}));
+
+        _dataSource = _mock.Object;
+    }
+
+}


### PR DESCRIPTION
# Pull Request

Issue Number: #397 

## Summary

Add cache functionality for emissions data to avoid too frequent access to the data sources.

## Changes

- Add a proxy for data sources to cache results for queries
- Add a configuration class to enable cache
- Modify service registration of data sources to use cache
- Write tests for verifying the configuration and  the functionality of the cache proxy
- Write document

## Checklist

- [x] Local Tests Passing?
- [ ] CICD and Pipeline Tests Passing?
- [x] Added any new Tests?
- [x] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [x] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?

No.

## Is this a breaking change?

No.

This PR Closes #397
