### PR TITLE
Add Prometheus exporter

### DIFF
--- a/casdk-docs/docs/tutorial-extras/configuration.md
+++ b/casdk-docs/docs/tutorial-extras/configuration.md
@@ -406,6 +406,8 @@ AppInsights_InstrumentationKey="AppInsightsInstrumentationKey"
 
 ### Prometheus exporter for emissions data
 
+> DISCLAIMER:  The `/metrics` Prometheus exporter is currently unsupported, and is used for internal GSF needs, and may change in the future.  It will retrieve _all_ emissions data and create heavy load on your data API's.  It is turned off by default.
+
 In the WebApi project, this application can exporse latest carbon emissions data as a prometheus exporter.
 
 ```bash

--- a/casdk-docs/docs/tutorial-extras/configuration.md
+++ b/casdk-docs/docs/tutorial-extras/configuration.md
@@ -23,6 +23,7 @@
   - [CarbonAwareVars](#carbonawarevars)
     - [Tracing and Monitoring Configuration](#tracing-and-monitoring-configuration)
     - [Verbosity](#verbosity)
+    - [Prometheus exporter](#prometheus-exporter-for-emissions-data)
     - [Web API Prefix](#web-api-prefix)
   - [LocationDataSourcesConfiguration](#locationdatasourcesconfiguration)
 - [Sample Configurations](#sample-configurations)
@@ -414,6 +415,17 @@ The scraping endpoint is `<ROOT_PATH>/metrics` like this:
 
 ```bash
 http://localhost/metrics
+```
+
+By default, the exposed data are latest ones within last 24 hours. If you would like to change the period 
+in some reasones, you can configure the value like this:
+
+```json
+{
+  "CarbonExporter": {
+    "PeriodInHours": 48
+  }
+}
 ```
 
 ### Verbosity

--- a/casdk-docs/docs/tutorial-extras/configuration.md
+++ b/casdk-docs/docs/tutorial-extras/configuration.md
@@ -403,6 +403,19 @@ InstrumentationKey. For more details, please refer to
 AppInsights_InstrumentationKey="AppInsightsInstrumentationKey"
 ```
 
+### Prometheus exporter for emissions data
+
+In the WebApi project, this application can exporse latest carbon emissions data as a prometheus exporter.
+
+```bash
+CarbonAwareVars__EnableCarbonExporter="true"
+```
+The scraping endpoint is `<ROOT_PATH>/metrics` like this:
+
+```bash
+http://localhost/metrics
+```
+
 ### Verbosity
 
 You can configure the verbosity of the application error messages by setting the

--- a/src/CarbonAware.WebApi/src/CarbonAware.WebApi.csproj
+++ b/src/CarbonAware.WebApi/src/CarbonAware.WebApi.csproj
@@ -15,12 +15,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0-rc.1.23419.4" />
+    <PackageReference Include="Opentelemetry.Exporter.Prometheus.AspNetCore" Version="1.6.0-rc.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets"
       Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.4.0-beta.3" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.9" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.9" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.9" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.5.1-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.5.1-beta.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.4.0" />

--- a/src/CarbonAware.WebApi/src/Configuration/CarbonExporterConfiguration.cs
+++ b/src/CarbonAware.WebApi/src/Configuration/CarbonExporterConfiguration.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.Configuration;
+
+namespace CarbonAware.WebApi.Configuration;
+
+
+internal class CarbonExporterConfiguration
+{
+    public const string Key = "CarbonExporter";
+
+    public int PeriodInHours { get; set; } = 24;
+
+    public void AssertValid()
+    {
+        if(PeriodInHours <= 0)
+        {
+            throw new ArgumentException($"The value of CarbonExporter.PeriodInHours must be greater than 0.");
+        }
+    }
+}

--- a/src/CarbonAware.WebApi/src/Configuration/ServiceCollectionExtensions.cs
+++ b/src/CarbonAware.WebApi/src/Configuration/ServiceCollectionExtensions.cs
@@ -40,6 +40,12 @@ internal static class ServiceCollectionExtensions
         var envVars = configuration?.GetSection(CarbonAwareVariablesConfiguration.Key).Get<CarbonAwareVariablesConfiguration>();
         var enableCarbonExporter = envVars?.EnableCarbonExporter ?? false;
         if(enableCarbonExporter){
+            var carbonExporter = configuration?.GetSection(CarbonExporterConfiguration.Key);
+            services.Configure<CarbonExporterConfiguration>(c => 
+            {
+                carbonExporter?.Bind(c);
+            });
+
             services.AddOpenTelemetry()
                 .WithMetrics(meterProviderBuilder =>
                     meterProviderBuilder

--- a/src/CarbonAware.WebApi/src/Metrics/CarbonMetrics.cs
+++ b/src/CarbonAware.WebApi/src/Metrics/CarbonMetrics.cs
@@ -1,0 +1,87 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using GSF.CarbonAware.Handlers;
+using GSF.CarbonAware.Models;
+
+namespace CarbonAware.WebApi.Metrics;
+
+public class CarbonMetrics : IDisposable
+{
+    private readonly ILogger<CarbonMetrics> _logger;
+
+    internal const string MeterName = "Carbon.Aware.Metric";
+    internal const string ActivitySourceName = "Carbon.Aware.Metric";
+    internal const string GaugeName = "carbon.aware.intensity";
+
+    public ActivitySource ActivitySource { get; }
+
+    private readonly IEmissionsHandler _emissionsHandler;
+    private readonly ILocationHandler _locationHandler;
+
+    private readonly Meter _meter;
+
+    private readonly ConcurrentBag<string> _locations = new ConcurrentBag<string>();
+    private readonly IDictionary<string, ObservableGauge<double>> _gauges = new ConcurrentDictionary<string, ObservableGauge<double>>();
+
+    public CarbonMetrics(IMeterFactory meterFactory, ILogger<CarbonMetrics> logger, IEmissionsHandler emissionsHandler, ILocationHandler locationHandler)
+    {
+        _emissionsHandler = emissionsHandler ?? throw new ArgumentNullException(nameof(emissionsHandler));
+        _locationHandler = locationHandler ?? throw new ArgumentNullException(nameof(locationHandler));
+        _logger = logger;
+
+        string? version = typeof(CarbonMetrics).Assembly.GetName().Version?.ToString();
+        ActivitySource = new ActivitySource(ActivitySourceName, version);
+        _meter = meterFactory.Create(MeterName, version);
+        InitLocations();
+    }
+
+    private void InitLocations()
+    {
+        // initialize locations and guages
+        _locations.Clear();
+        _gauges.Clear();
+
+        // load locations
+        Task<IDictionary<string, Location>> locationsTask = _locationHandler.GetLocationsAsync();
+        try
+        {
+            locationsTask.Result.Keys.ToList().ForEach(d => _locations.Add(d));
+            // create guages for each locaton
+            foreach(var loc in _locations){
+                _gauges[loc] = _meter.CreateObservableGauge(CarbonMetrics.GaugeName, () => GetIntensity(loc));
+            }
+        }
+        catch(Exception ex)
+        {
+            _logger.LogWarning(ex.Message);
+            _locations.Clear();
+            _gauges.Clear();
+        }
+    }
+
+    public void Dispose()
+    {
+        _meter.Dispose();
+        ActivitySource.Dispose();
+    }
+
+    private Measurement<double> GetIntensity(string location){
+        try
+        {
+            var end = DateTimeOffset.UtcNow;
+            var start = end.AddDays(-1);
+            var intensity = _emissionsHandler.GetEmissionsDataAsync(location, start, end)
+                .Result
+                .MaxBy(d => d.Time)!
+                .Rating;
+            var measurement = new Measurement<double>(intensity, new TagList(){{"location", location}});
+            return measurement;
+        }
+        catch(Exception ex)
+        {
+            _logger.LogWarning(ex.Message);
+            return new Measurement<double>(0, new TagList(){{"location", location}});
+        }
+    }
+}

--- a/src/CarbonAware.WebApi/src/Metrics/CarbonMetrics.cs
+++ b/src/CarbonAware.WebApi/src/Metrics/CarbonMetrics.cs
@@ -1,15 +1,19 @@
+using CarbonAware.WebApi.Configuration;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using Microsoft.Extensions.Options;
 using GSF.CarbonAware.Handlers;
 using GSF.CarbonAware.Models;
 
 namespace CarbonAware.WebApi.Metrics;
 
-public class CarbonMetrics : IDisposable
+internal class CarbonMetrics : IDisposable
 {
     private readonly ILogger<CarbonMetrics> _logger;
 
+    private readonly IOptionsMonitor<CarbonExporterConfiguration> _configurationMonitor;
+    private CarbonExporterConfiguration _configuration => this._configurationMonitor.CurrentValue;
     internal const string MeterName = "Carbon.Aware.Metric";
     internal const string ActivitySourceName = "Carbon.Aware.Metric";
     internal const string GaugeName = "carbon.aware.intensity";
@@ -24,11 +28,13 @@ public class CarbonMetrics : IDisposable
     private readonly ConcurrentBag<string> _locations = new ConcurrentBag<string>();
     private readonly IDictionary<string, ObservableGauge<double>> _gauges = new ConcurrentDictionary<string, ObservableGauge<double>>();
 
-    public CarbonMetrics(IMeterFactory meterFactory, ILogger<CarbonMetrics> logger, IEmissionsHandler emissionsHandler, ILocationHandler locationHandler)
+    public CarbonMetrics(IMeterFactory meterFactory, IOptionsMonitor<CarbonExporterConfiguration> monitor, ILogger<CarbonMetrics> logger, IEmissionsHandler emissionsHandler, ILocationHandler locationHandler)
     {
         _emissionsHandler = emissionsHandler ?? throw new ArgumentNullException(nameof(emissionsHandler));
         _locationHandler = locationHandler ?? throw new ArgumentNullException(nameof(locationHandler));
+        _configurationMonitor = monitor;
         _logger = logger;
+        _configuration.AssertValid();
 
         string? version = typeof(CarbonMetrics).Assembly.GetName().Version?.ToString();
         ActivitySource = new ActivitySource(ActivitySourceName, version);
@@ -70,7 +76,7 @@ public class CarbonMetrics : IDisposable
         try
         {
             var end = DateTimeOffset.UtcNow;
-            var start = end.AddDays(-1);
+            var start = end.AddHours(-1*_configuration.PeriodInHours);
             var intensity = _emissionsHandler.GetEmissionsDataAsync(location, start, end)
                 .Result
                 .MaxBy(d => d.Time)!

--- a/src/CarbonAware.WebApi/src/Metrics/MetricsResourceDetector.cs
+++ b/src/CarbonAware.WebApi/src/Metrics/MetricsResourceDetector.cs
@@ -1,0 +1,17 @@
+using CarbonAware.WebApi.Metrics;
+using OpenTelemetry.Resources;
+
+public class MetricsResourceDetector : IResourceDetector
+{
+    private readonly CarbonMetrics _carbonMetrics;
+
+    public MetricsResourceDetector(CarbonMetrics carbonMetrics)
+    {
+        _carbonMetrics = carbonMetrics;
+    }
+
+    public Resource Detect()
+    {
+        return ResourceBuilder.CreateEmpty().Build();
+    }
+}

--- a/src/CarbonAware.WebApi/src/Metrics/MetricsResourceDetector.cs
+++ b/src/CarbonAware.WebApi/src/Metrics/MetricsResourceDetector.cs
@@ -1,7 +1,7 @@
 using CarbonAware.WebApi.Metrics;
 using OpenTelemetry.Resources;
 
-public class MetricsResourceDetector : IResourceDetector
+internal class MetricsResourceDetector : IResourceDetector
 {
     private readonly CarbonMetrics _carbonMetrics;
 

--- a/src/CarbonAware.WebApi/src/Program.cs
+++ b/src/CarbonAware.WebApi/src/Program.cs
@@ -7,6 +7,7 @@ using GSF.CarbonAware.Exceptions;
 using Microsoft.OpenApi.Models;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
+using OpenTelemetry.Metrics;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using System.Reflection;
 
@@ -16,17 +17,16 @@ var serviceVersion = "1.0.0";
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddOpenTelemetryTracing(tracerProviderBuilder =>
-{
-    tracerProviderBuilder
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracerProviderBuilder =>
+        tracerProviderBuilder
         .AddConsoleExporter()
         .AddSource(serviceName)
         .SetResourceBuilder(
             ResourceBuilder.CreateDefault()
                 .AddService(serviceName: serviceName, serviceVersion: serviceVersion))
         .AddHttpClientInstrumentation()
-        .AddAspNetCoreInstrumentation();
-});
+        .AddAspNetCoreInstrumentation());
 
 // Add services to the container.
 builder.Services.AddControllers(options =>
@@ -70,6 +70,8 @@ builder.Services.AddHealthChecks();
 
 builder.Services.AddMonitoringAndTelemetry(builder.Configuration);
 
+builder.Services.AddCarbonExporter(builder.Configuration);
+
 builder.Services.AddSwaggerGen(c => {
         c.MapType<TimeSpan>(() => new OpenApiSchema { Type = "string", Format = "time-span" });
     });
@@ -111,6 +113,11 @@ app.UseAuthorization();
 app.MapControllers();
 
 app.MapHealthChecks("/health");
+
+var enableCarbonExporter = config?.EnableCarbonExporter ?? false;
+if(enableCarbonExporter){
+    app.UseOpenTelemetryPrometheusScrapingEndpoint();
+}
 
 app.Run();
 

--- a/src/CarbonAware.WebApi/test/integrationTests/CarbonAwareControllerTests.cs
+++ b/src/CarbonAware.WebApi/test/integrationTests/CarbonAwareControllerTests.cs
@@ -20,6 +20,7 @@ class CarbonAwareControllerTests : IntegrationTestingBase
 {
     private readonly string healthURI = "/health";
     private readonly string fakeURI = "/fake-endpoint";
+    private readonly string metricsURI = "/metrics";
     private readonly string bestLocationsURI = "/emissions/bylocations/best";
     private readonly string bylocationsURI = "/emissions/bylocations";
     private readonly string bylocationURI = "/emissions/bylocation";
@@ -46,6 +47,16 @@ class CarbonAwareControllerTests : IntegrationTestingBase
         Assert.That(result, Is.Not.Null);
         Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
     }
+
+    [Test]
+    public async Task MetricsEndPoint_ReturnsOK()
+    {
+        //Use client to get endpoint
+        var result = await _client.GetAsync(metricsURI);
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+    }
+
 
     //ISO8601: YYYY-MM-DD
     [TestCase("2022-1-1T04:05:06Z", "2022-1-2T04:05:06Z", "eastus", nameof(ByLocationURI_ReturnsOK) + "0")]

--- a/src/CarbonAware.WebApi/test/integrationTests/IntegrationTestingBase.cs
+++ b/src/CarbonAware.WebApi/test/integrationTests/IntegrationTestingBase.cs
@@ -21,6 +21,7 @@ internal abstract class IntegrationTestingBase
     internal DataSourceType _dataSource;
     internal string? _emissionsDataSourceEnv;
     internal string? _forecastDataSourceEnv;
+    internal string? _enableCarbonExporterEnv;
     internal WebApplicationFactory<Program> _factory;
     protected HttpClient _client;
     internal IDataSourceMocker _dataSourceMocker;
@@ -33,6 +34,7 @@ internal abstract class IntegrationTestingBase
         _dataSource = dataSource;
         _emissionsDataSourceEnv = null;
         _forecastDataSourceEnv = null;
+        _enableCarbonExporterEnv = null;
         _factory = new WebApplicationFactory<Program>();
     }
 
@@ -77,6 +79,8 @@ internal abstract class IntegrationTestingBase
     {
         _emissionsDataSourceEnv = Environment.GetEnvironmentVariable("DataSources__EmissionsDataSource");
         _forecastDataSourceEnv = Environment.GetEnvironmentVariable("DataSources__ForecastDataSource");
+        _enableCarbonExporterEnv = Environment.GetEnvironmentVariable("CarbonAwareVars__EnableCarbonExporter");
+        Environment.SetEnvironmentVariable("CarbonAwareVars__EnableCarbonExporter", "true");
         //Switch between different data sources as needed
         //Each datasource should have an accompanying DataSourceMocker that will perform setup activities
         switch (_dataSource)
@@ -153,5 +157,6 @@ internal abstract class IntegrationTestingBase
         _dataSourceMocker?.Dispose();
         Environment.SetEnvironmentVariable("DataSources__EmissionsDataSource", _emissionsDataSourceEnv);
         Environment.SetEnvironmentVariable("DataSources__ForecastDataSource", _forecastDataSourceEnv);
+        Environment.SetEnvironmentVariable("CarbonAwareVars__EnableCarbonMetrics", _enableCarbonExporterEnv);
     }
 }

--- a/src/CarbonAware.WebApi/test/unitTests/Configuration/CarbonExporterConfigurationTests.cs
+++ b/src/CarbonAware.WebApi/test/unitTests/Configuration/CarbonExporterConfigurationTests.cs
@@ -1,0 +1,30 @@
+using CarbonAware.WebApi.Configuration;
+using NUnit.Framework;
+
+namespace CarbonAware.WepApi.UnitTests;
+
+class CarbonExporterConfigurationTests
+{
+    [TestCase(12, TestName = "AssertValid: PeriodInHours greater than 0")]
+    [TestCase(1, TestName = "AssertValid: PeriodInHours equals to 1")]
+    public void AssertValid_PeriodInHoursGreaterThanZero_DoesNotThrowException(int periodInHours)
+    {
+        CarbonExporterConfiguration carbonExporterConfiguration = new CarbonExporterConfiguration()
+        {
+            PeriodInHours = periodInHours
+        };
+
+        Assert.DoesNotThrow(() => carbonExporterConfiguration.AssertValid());
+    }
+
+    [TestCase(0, TestName = "AssertValid: PeriodInHours equals to 0")]
+    public void AssertValid_PeriodInHoursGreaterThanZero_ThrowException(int periodInHours)
+    {
+        CarbonExporterConfiguration carbonExporterConfiguration = new CarbonExporterConfiguration()
+        {
+            PeriodInHours = periodInHours
+        };
+
+        Assert.Throws<ArgumentException>(() => carbonExporterConfiguration.AssertValid());
+    }
+}

--- a/src/CarbonAware.WebApi/test/unitTests/Configuration/ServiceCollectionExtensionsTests.cs
+++ b/src/CarbonAware.WebApi/test/unitTests/Configuration/ServiceCollectionExtensionsTests.cs
@@ -83,6 +83,61 @@ public class ServiceCollectionExtensionsTests
     }    
 
     [Test]
+    public void AddCarbonExporter_AddsServices_IsEnabledInConfiguration()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        var inMemorySettings = new Dictionary<string, string>
+        {
+            { "CarbonAwareVars:EnableCarbonExporter", "true" }
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(inMemorySettings)
+            .Build();
+
+        // Act & Assert
+        Assert.DoesNotThrow(() => services.AddCarbonExporter(configuration));
+        Assert.That(services.Count, Is.GreaterThan(0));
+    }
+
+    [Test]
+    public void AddCarbonExporter_DoesNotAddServices_IsDisabledInConfiguration()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        var inMemorySettings = new Dictionary<string, string>
+        {
+            { "CarbonAwareVars:EnableCarbonExporter", "false" }
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(inMemorySettings)
+            .Build();
+
+        // Act & Assert
+        Assert.DoesNotThrow(() => services.AddCarbonExporter(configuration));
+        Assert.That(services.Count, Is.EqualTo(0));
+    }
+
+
+    [Test]
+    public void AddCarbonExporter_DoesNotAddServices_WithoutConfiguration()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        var inMemorySettings = new Dictionary<string, string>{};
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(inMemorySettings)
+            .Build();
+
+        // Act & Assert
+        Assert.DoesNotThrow(() => services.AddCarbonExporter(configuration));
+        Assert.That(services.Count, Is.EqualTo(0));
+    }
+
+    [Test]
     public void CreateConsoleLogger_ReturnsILogger()
     {
         // Arrange

--- a/src/CarbonAware/src/CarbonAwareVariablesConfiguration.cs
+++ b/src/CarbonAware/src/CarbonAwareVariablesConfiguration.cs
@@ -36,6 +36,8 @@ internal class CarbonAwareVariablesConfiguration
 
     public string TelemetryProvider { get; set; }
 
+    public Boolean EnableCarbonExporter { get;set; }
+
     public Boolean VerboseApi {get; set;}
 
 }

--- a/src/GSF.CarbonAware/src/Configuration/ServiceCollectionExtensions.cs
+++ b/src/GSF.CarbonAware/src/Configuration/ServiceCollectionExtensions.cs
@@ -11,15 +11,22 @@ namespace GSF.CarbonAware.Configuration;
 
 public static class ServiceCollectionExtensions
 {
-    /// <summary>
-    /// Add services needed in order to use an Emissions service.
-    /// </summary>
-    public static IServiceCollection AddEmissionsServices(this IServiceCollection services, IConfiguration configuration)
+
+    private  static IServiceCollection ConfigureLocationDataSourcesConfiguration(this IServiceCollection services, IConfiguration configuration)
     {
         services.Configure<LocationDataSourcesConfiguration>(c =>
         {
             configuration.GetSection(LocationDataSourcesConfiguration.Key).Bind(c);
         });
+        return services;
+    }
+
+    /// <summary>
+    /// Add services needed in order to use an Emissions service.
+    /// </summary>
+    public static IServiceCollection AddEmissionsServices(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.ConfigureLocationDataSourcesConfiguration(configuration);
         services.TryAddSingleton<ILocationSource, LocationSource>();
         services.AddDataSourceService(configuration);
         services.TryAddSingleton<IEmissionsHandler, EmissionsHandler>();
@@ -32,10 +39,7 @@ public static class ServiceCollectionExtensions
     /// </summary>
     public static IServiceCollection AddForecastServices(this IServiceCollection services, IConfiguration configuration)
     {
-        services.Configure<LocationDataSourcesConfiguration>(c =>
-        {
-            configuration.GetSection(LocationDataSourcesConfiguration.Key).Bind(c);
-        });
+        services.ConfigureLocationDataSourcesConfiguration(configuration);
         services.TryAddSingleton<ILocationSource, LocationSource>();
         services.AddDataSourceService(configuration);
         services.TryAddSingleton<IForecastHandler, ForecastHandler>();


### PR DESCRIPTION
# Pull Request

Issue Number: #400

## Summary

Add Prometheus exporter to CA SDK Web API. It exposes latest emission data for each configured location.

**This PR is based upon #404.**

## Changes

- Add metrics to expose emission data
- Enable the endpoint for scraping by Prometheus
- Add configurations 
- Add tests
- Write documents

## Checklist

- [x] Local Tests Passing?
- [ ] CICD and Pipeline Tests Passing?
- [x] Added any new Tests?
- [x] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [x] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?

No.

## Is this a breaking change?

No.

This PR Closes #400