### PR TITLE
Support location source setting in Helm chart

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -355,6 +355,40 @@ appsettings: |-
       }
     }
   }
+
+# Location source
+# Location data will be deployed into /app/location-sources/json .
+locationSources:
+  enabled: false
+#  files:
+#  - fileName: custom-locations-1.json
+#    locations: |-
+#      {
+#        "east": {
+#          "Latitude": "35.68",
+#          "Longitude": "139.77",
+#          "Name": "eastdc"
+#        },
+#        "west": {
+#          "Latitude": "34.6939",
+#          "Longitude": "135.5022",
+#          "Name": "westdc"
+#        }
+#      }
+#  - fileName: custom-locations-2.json
+#    locations: |-
+#      {
+#        "north": {
+#         "Latitude": "35.68",
+#          "Longitude": "139.77",
+#          "Name": "northdc"
+#        },
+#        "south": {
+#          "Latitude": "34.6939",
+#          "Longitude": "135.5022",
+#          "Name": "southdc"
+#        }
+#      }
 ```
 
 The video in below is demonstration to install Carbon Aware SDK via Helm. Note that installing the SDK from local directory ( ~/github-forked/carbon-aware-sdk/helm-chart ), not an OCI container.

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-chart/templates/configmap.yaml
+++ b/helm-chart/templates/configmap.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.locationSources.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: location-sources
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "carbon-aware-sdk.labels" . | nindent 4 }}
+data:
+  {{- range .Values.locationSources.files }}
+  {{ .fileName }}: {{- toYaml .locations | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -46,6 +46,11 @@ spec:
               mountPath: /app/appsettings.json
               subPath: appsettings.json
               readOnly: true
+            {{- if .Values.locationSources.enabled }}
+            - name: location-sources
+              mountPath: /app/location-sources/json
+              readOnly: true
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /health
@@ -60,6 +65,16 @@ spec:
         - name: appsettings
           secret:
             secretName: appsettings
+        {{- if .Values.locationSources.enabled }}
+        - name: location-sources
+          configMap:
+            name: location-sources
+            items:
+            {{- range .Values.locationSources.files }}
+            - key: {{ .fileName }}
+              path: {{ .fileName }}
+            {{- end }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -108,3 +108,37 @@ appsettings: |-
       }
     }
   }
+
+# Location source
+# Location data will be deployed into /app/location-sources/json .
+locationSources:
+  enabled: false
+#  files:
+#  - fileName: custom-locations-1.json
+#    locations: |-
+#      {
+#        "east": {
+#          "Latitude": "35.68",
+#          "Longitude": "139.77",
+#          "Name": "eastdc"
+#        },
+#        "west": {
+#          "Latitude": "34.6939",
+#          "Longitude": "135.5022",
+#          "Name": "westdc"
+#        }
+#      }
+#  - fileName: custom-locations-2.json
+#    locations: |-
+#      {
+#        "north": {
+#         "Latitude": "35.68",
+#          "Longitude": "139.77",
+#          "Name": "northdc"
+#        },
+#        "south": {
+#          "Latitude": "34.6939",
+#          "Longitude": "135.5022",
+#          "Name": "southdc"
+#        }
+#      }

--- a/src/CarbonAware.LocationSources/src/LocationSource.cs
+++ b/src/CarbonAware.LocationSources/src/LocationSource.cs
@@ -109,7 +109,7 @@ internal class LocationSource : ILocationSource
             return Array.Empty<LocationSourceFile>();
         }
         _logger.LogInformation($"{files.Count()} files discovered");
-        return files.Select(x => x.Substring(pathCombined.Length + 1)).Select(n => new LocationSourceFile { DataFileLocation = n });
+        return files.Select(x => x.Substring(pathCombined.Length + 1)).Where(n => !n.StartsWith("..")).Select(n => new LocationSourceFile { DataFileLocation = n });
     }
 
     private void AddToLocationMap(string key, NamedGeoposition data, string sourceFile, Dictionary<string, int> keyCounter)


### PR DESCRIPTION
# Pull Request

## Summary

Add location source configuration to Helm chart

## Changes

- Add `locationSources` key to configure location source JSON.
- Ignore files which starts with `..` in `location-source` directory (Kubernetes sets real configuration file with `..`)
- Update documents for Helm

## Checklist

- [ ] Local Tests Passing?
- [ ] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [x] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [ ] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?

No

## Is this a breaking change?

No

## Anything else?

I want to update Helm chart version and to publish new chart container if this PR is accepted.