### PR TITLE
[URGENT] WebAPI container has not built due to segmentation fault

### DIFF
--- a/.github/workflows/2-pre-release.yaml
+++ b/.github/workflows/2-pre-release.yaml
@@ -23,8 +23,6 @@ jobs:
     permissions:
       packages: write
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Log in to the Container registry

--- a/.github/workflows/4-release.yaml
+++ b/.github/workflows/4-release.yaml
@@ -14,8 +14,6 @@ jobs:
     permissions:
       packages: write
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Log in to the Container registry

--- a/src/CarbonAware.WebApi/src/Dockerfile
+++ b/src/CarbonAware.WebApi/src/Dockerfile
@@ -1,11 +1,12 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+ARG TARGETARCH
 WORKDIR /app
 
 ENV DOTNET_ROLL_FORWARD LatestMajor
 # Copy everything from source
 COPY . ./
 # Use implicit restore to build and publish
-RUN dotnet publish CarbonAware.WebApi/src/CarbonAware.WebApi.csproj -c Release -o publish
+RUN dotnet publish CarbonAware.WebApi/src/CarbonAware.WebApi.csproj -a $TARGETARCH -o publish
 # Generate OpenAPI spec
 WORKDIR /app/CarbonAware.WebApi/src
 RUN dotnet tool restore && \

--- a/src/CarbonAware.WebApi/src/Dockerfile
+++ b/src/CarbonAware.WebApi/src/Dockerfile
@@ -1,24 +1,33 @@
+# For OpenAPI document
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS openapi-env
+WORKDIR /app
+ENV DOTNET_ROLL_FORWARD LatestMajor
+COPY . ./
+RUN dotnet build CarbonAware.WebApi/src/CarbonAware.WebApi.csproj -o build
+WORKDIR /app/CarbonAware.WebApi/src
+RUN dotnet tool restore && \
+    dotnet tool run swagger tofile --output /app/build/swagger.yaml --yaml /app/build/CarbonAware.WebApi.dll v1
+
+
+# Builder
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
 ARG TARGETARCH
 WORKDIR /app
-
 ENV DOTNET_ROLL_FORWARD LatestMajor
 # Copy everything from source
 COPY . ./
 # Use implicit restore to build and publish
 RUN dotnet publish CarbonAware.WebApi/src/CarbonAware.WebApi.csproj -a $TARGETARCH -o publish
-# Generate OpenAPI spec
-WORKDIR /app/CarbonAware.WebApi/src
-RUN dotnet tool restore && \
-    mkdir -p /app/publish/wwwroot/api/v1 && \
-    dotnet tool run swagger tofile --output /app/publish/wwwroot/api/v1/swagger.yaml --yaml /app/publish/CarbonAware.WebApi.dll v1
+
 
 # Build runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:8.0
 # Install curl for health check
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl
-# Copy artifacts from build-env
+# Copy artifacts
 WORKDIR /app
 COPY --from=build-env /app/publish .
+RUN mkdir -p /app/wwwroot/api/v1
+COPY --from=openapi-env /app/build/swagger.yaml /app/wwwroot/api/v1/
 ENTRYPOINT ["dotnet", "CarbonAware.WebApi.dll"]

--- a/src/GSF.CarbonAware/src/GSF.CarbonAware.csproj
+++ b/src/GSF.CarbonAware/src/GSF.CarbonAware.csproj
@@ -37,6 +37,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.2.8" />
     <PackageReference Include="WireMock.Net" Version="1.5.6" />
+    <PackageReference Include="Microsoft.NETCore.Targets" Version="3.0.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Pull Request

#496

## Summary

Use RID to build WebAPI container.

## Changes

- Use RID to build WebAPI container - QEMU is not supported in .NET https://devblogs.microsoft.com/dotnet/improving-multiplatform-container-support/
- Fix version confliction in `System.IO.FileSystem.Primitives` https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1605#example-3
- Separate OpenAPI document generation from `build-env` stage in WebAPI Dockerfile

You can test new container images from my forked repo. They works fine on both Linux x64 and Arm64 (Raspberry Pi) https://github.com/YaSuenag/carbon-aware-sdk/pkgs/container/carbon-aware-sdk/201841709?tag=v99.0.3

## Checklist

- [x] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [x] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?

No

## Is this a breaking change?

No

This PR Closes #496
