### PR TITLE
Up Helm chart version to 1.2.0

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.1.0"
+appVersion: "v1.4.0"


### PR DESCRIPTION
# Pull Request

## Summary

Up Helm chart version to 1.2.0 because WebAPI would publish port 8080 due to .NET 8 migration since CASDK v1.4 . So I've also updated `appVersion` to v1.4.0.

> [!IMPORTANT]
> This should be merged after v1.4.0 release, then CASDK maintainer should be kick [5-publish-helm-chart.yaml](https://github.com/Green-Software-Foundation/carbon-aware-sdk/blob/dev/.github/workflows/5-publish-helm-chart.yaml) manually to publish new Helm chart to [charts/carbon-aware-sdk](https://github.com/Green-Software-Foundation/carbon-aware-sdk/pkgs/container/charts%2Fcarbon-aware-sdk).

## Changes

- helm-chart/Chart.yaml

## Checklist

- [ ] Local Tests Passing?
- [ ] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [x] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?

No

## Is this a breaking change?

No