### PR TITLE
Remove Hack mention from the Docs's banner

### DIFF
--- a/casdk-docs/docusaurus.config.js
+++ b/casdk-docs/docusaurus.config.js
@@ -130,7 +130,7 @@ const config = {
         id: 'announcementBar-0', // Increment on change
         // content: `⭐️ If you like Docusaurus, give it a star on <a target="_blank" rel="noopener noreferrer" href="https://github.com/facebook/docusaurus">GitHub</a> and follow us on <a target="_blank" rel="noopener noreferrer" href="https://twitter.com/docusaurus">Twitter ${TwitterSvg}</a>`,
         //content: `🎉️ <b><a target="_blank" href="https://docusaurus.io/blog/releases/3.0">Docusaurus v3.0</a> is now out!</b> 🥳️`,
-        content:`<strong>\u26A0 Graduated Project: This project is a Graduated Project, supported by the Green Software Foundation. The publicly available version documented in the README is trusted by the GSF. New versions of the project may be released, or it may move to the Maintained or Archived Stage. <br><br> 🎉️ We are running a Hackathon! CarbonHack is open to all, including software practitioners and those with a passion for Green Software. Find out more on the <a href="https://grnsft.org/hack/github">CarbonHack website</a> </strong>`,
+        content:`<strong>\u26A0 Graduated Project: This project is a Graduated Project, supported by the Green Software Foundation. The publicly available version documented in the README is trusted by the GSF. New versions of the project may be released, or it may move to the Maintained or Archived Stage. `,
         backgroundColor:'#EBF2D7',
         textColor:'#00524f'
       },

--- a/casdk-docs/docusaurus.config.js
+++ b/casdk-docs/docusaurus.config.js
@@ -130,7 +130,7 @@ const config = {
         id: 'announcementBar-0', // Increment on change
         // content: `⭐️ If you like Docusaurus, give it a star on <a target="_blank" rel="noopener noreferrer" href="https://github.com/facebook/docusaurus">GitHub</a> and follow us on <a target="_blank" rel="noopener noreferrer" href="https://twitter.com/docusaurus">Twitter ${TwitterSvg}</a>`,
         //content: `🎉️ <b><a target="_blank" href="https://docusaurus.io/blog/releases/3.0">Docusaurus v3.0</a> is now out!</b> 🥳️`,
-        content:`<strong>\u26A0 Graduated Project: This project is a Graduated Project, supported by the Green Software Foundation. The publicly available version documented in the README is trusted by the GSF. New versions of the project may be released, or it may move to the Maintained or Archived Stage. `,
+        content:`<strong>\u26A0 Graduated Project: This project is a Graduated Project, supported by the Green Software Foundation. The publicly available version documented in the README is trusted by the GSF. New versions of the project may be released, or it may move to the Maintained or Archived Stage.</strong> `,
         backgroundColor:'#EBF2D7',
         textColor:'#00524f'
       },


### PR DESCRIPTION
removed banner's mention of Hack

# Pull Request

Issue Number: #519 

## Summary

One sentence summary of PR

## Changes

- removed the mention of the Carbon Hack 24

## Checklist

- [ ] Local Tests Passing?
- [ ] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [ ] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?

If yes, what are the expected API Changes? Please link to an API-Comparison
workflow with the API Diff.

## Is this a breaking change?

If yes, what workflow does this break?

## Anything else?

Other comments, collaborators, etc.

> Please follow
> [GitHub's suggested syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
> to link Pull Requests to Issues via keywords

This PR Closes #519 
