### PR TITLE
Add configuration for tracing log

### DIFF
--- a/casdk-docs/docs/tutorial-extras/configuration.md
+++ b/casdk-docs/docs/tutorial-extras/configuration.md
@@ -404,6 +404,16 @@ InstrumentationKey. For more details, please refer to
 AppInsights_InstrumentationKey="AppInsightsInstrumentationKey"
 ```
 
+#### Configuring telemetry log
+
+WebAPI configures [console exporter of OpenTelemetry](https://opentelemetry.io/docs/languages/net/exporters/#console) by default.
+You can configure whether the exporter is enabled with `EnableTelemetryLogging`.
+Set `false` if you want to reduce the log.
+
+```bash
+CarbonAwareVars__EnableTelemetryLogging=false
+```
+
 ### Prometheus exporter for emissions data
 
 > DISCLAIMER:  The `/metrics` Prometheus exporter is currently unsupported, and is used for internal GSF needs, and may change in the future.  It will retrieve _all_ emissions data and create heavy load on your data API's.  It is turned off by default.

--- a/src/CarbonAware.WebApi/src/Program.cs
+++ b/src/CarbonAware.WebApi/src/Program.cs
@@ -5,28 +5,10 @@ using CarbonAware.WebApi.Filters;
 using GSF.CarbonAware.Configuration;
 using GSF.CarbonAware.Exceptions;
 using Microsoft.OpenApi.Models;
-using OpenTelemetry.Resources;
-using OpenTelemetry.Trace;
-using OpenTelemetry.Metrics;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using System.Reflection;
 
-// Define constants to initialize tracing with
-var serviceName = "CarbonAware.WebAPI";
-var serviceVersion = "1.0.0";
-
 var builder = WebApplication.CreateBuilder(args);
-
-builder.Services.AddOpenTelemetry()
-    .WithTracing(tracerProviderBuilder =>
-        tracerProviderBuilder
-        .AddConsoleExporter()
-        .AddSource(serviceName)
-        .SetResourceBuilder(
-            ResourceBuilder.CreateDefault()
-                .AddService(serviceName: serviceName, serviceVersion: serviceVersion))
-        .AddHttpClientInstrumentation()
-        .AddAspNetCoreInstrumentation());
 
 // Add services to the container.
 builder.Services.AddControllers(options =>

--- a/src/CarbonAware/src/CarbonAwareVariablesConfiguration.cs
+++ b/src/CarbonAware/src/CarbonAwareVariablesConfiguration.cs
@@ -36,6 +36,8 @@ internal class CarbonAwareVariablesConfiguration
 
     public string TelemetryProvider { get; set; }
 
+    public Boolean EnableTelemetryLogging { get; set; }
+
     public Boolean EnableCarbonExporter { get;set; }
 
     public Boolean VerboseApi {get; set;}


### PR DESCRIPTION
# Pull Request

## Summary

Introduce new configuration `EnableTelemetryLogging` into `CarbonAwareVars`. This configures whether console exporter by OpenTelemetry is enabled. If you set this to `false`, following log would be gone:

```
Activity.TraceId:            46ba0749bdd2381c8f8aded1986e74b2
Activity.SpanId:             bcb76b5718c7df35
Activity.TraceFlags:         Recorded
Activity.ActivitySourceName: Microsoft.AspNetCore
Activity.DisplayName:        /health
Activity.Kind:               Server
Activity.StartTime:          2024-06-12T10:36:51.3093434Z
Activity.Duration:           00:00:00.0221267
Activity.Tags:
    net.host.name: localhost
    net.host.port: 8080
    http.method: GET
    http.scheme: http
    http.target: /health
    http.url: http://localhost:8080/health
    http.flavor: 1.1
    http.user_agent: curl/8.5.0
    http.status_code: 200
Resource associated with Activity:
    service.name: CarbonAware.WebAPI
    service.version: 1.0.0
    service.instance.id: d482b5d5-4448-4281-8da8-37677e70e389
    telemetry.sdk.name: opentelemetry
    telemetry.sdk.language: dotnet
    telemetry.sdk.version: 1.6.0
```

This configuration is set to `true` by default, so this change does not change current behavior.

## Changes

- Add `EnableTelemetryLogging`
- Move console exporter configuration to `ServiceCollectionExtensions.cs` from `Program.cs`
- Update document
- Update unit test

## Checklist

- [x] Local Tests Passing?
- [ ] CICD and Pipeline Tests Passing?
- [x] Added any new Tests?
- [x] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [ ] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?

No

## Is this a breaking change?

No