### PR TITLE
Add env directive to values.yaml and troubleshooting guide to avoid inotify limitation on Linux

### DIFF
--- a/casdk-docs/docs/overview/enablement.md
+++ b/casdk-docs/docs/overview/enablement.md
@@ -399,6 +399,8 @@ tolerations: []
 
 affinity: {}
 
+env: []
+
 # appsettings.json
 appsettings: |-
   {

--- a/casdk-docs/docs/troubleshooting.md
+++ b/casdk-docs/docs/troubleshooting.md
@@ -1,0 +1,25 @@
+---
+sidebar_position: 10
+---
+
+# Troubleshooting guide
+
+This chapter shows the hint of troubleshooting if you face trouble(s) when you use Carbon Aware SDK.
+
+- [System.IO.IOException caused by number of inotify instances](#systemioioexception-caused-by-number-of-inotify-instances)
+
+## System.IO.IOException caused by number of inotify instances
+
+You could see `System.IO.IOException` caused by number of inotify instances when you run Carbon Aware SDK on Linux.
+
+.NET runtime uses inotify to watch updating configuration file (e.g. `appsettings.json`). See [Microsoft Lean](https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/docker/?view=aspnetcore-8.0) and [discussion on GitHub](https://github.com/dotnet/AspNetCore.Docs/issues/19814) for details.
+
+It is useful for debugging, but it would not be needed in most of production system. So you can disable this feature via environment variable.
+
+You need to set `DOTNET_HOSTBUILDER__RELOADCONFIGONCHANGE=false` to avoid the problem. You can set this in `values.yaml` as following when you deploy WebAPI via Helm chart.
+
+```yaml
+env:
+  - name: DOTNET_HOSTBUILDER__RELOADCONFIGONCHANGE
+    value: "false"
+```

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -37,6 +37,8 @@ spec:
           {{- with .Values.image.pullPolicy }}
           imagePullPolicy: {{ . }}
           {{- end }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
           ports:
             - name: http
               containerPort: 8080

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -80,6 +80,8 @@ tolerations: []
 
 affinity: {}
 
+env: []
+
 # /app/appsettings.json
 appsettings: |-
   {


### PR DESCRIPTION
# Pull Request

#528 

## Summary

Add troubleshooting document to avoid `System.IO.IOException` caused by number of inotify instances on Linux, and add `env` directive to `values.yaml` in Helm chart. See #528 for details.

## Changes

- CASDK document
- `values.yaml` in Helm chart

## Checklist

- [ ] Local Tests Passing?
- [ ] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [x] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [x] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?

No

## Is this a breaking change?

No

This PR Closes #528 