### PR TITLE
Add a configuration for disabling to cache JSON emission data

### DIFF
--- a/casdk-docs/docs/tutorial-extras/configuration.md
+++ b/casdk-docs/docs/tutorial-extras/configuration.md
@@ -202,6 +202,11 @@ where the assembly `CarbonAware.WebApi.dll` is located under `data-sources/json`
 directory. For instance, if the application is installed under `/app`, copy the
 file to `/app/data-sources/json`.
 
+Emission data in JSON is cached by default, it means original data would be handled
+even if JSON is updated.
+You need to set `DataSources__Configurations__JSON__CacheJsonData=false`
+if you want to handle updated data.
+
 ```sh
 cp <mydir>/mycustomfile.json /app/data-sources/json
 export DataSources__Configurations=Json

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/mock/JsonDataSourceMocker.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/mock/JsonDataSourceMocker.cs
@@ -4,7 +4,7 @@ using CarbonAware.Model;
 using System.Text.Json;
 
 namespace CarbonAware.DataSources.Json.Mocks;
-internal class JsonDataSourceMocker : IDataSourceMocker
+public class JsonDataSourceMocker : IDataSourceMocker
 {
     public JsonDataSourceMocker() { }
 

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/src/Configuration/JsonDataSourceConfiguration.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/src/Configuration/JsonDataSourceConfiguration.cs
@@ -30,11 +30,14 @@ internal class JsonDataSourceConfiguration
         }
     }
 
+    public bool CacheJsonData { get; set; }
+
     public JsonDataSourceConfiguration()
     {
         var assemblyPath = Assembly.GetExecutingAssembly().Location;
         assemblyDirectory = Path.GetDirectoryName(assemblyPath)!;
         DataFileLocation = DefaultDataFile;
+        CacheJsonData = true;
     }
 
     private static bool IsValidDirPath(string fileName)

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/src/JsonDataSource.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/src/JsonDataSource.cs
@@ -104,11 +104,11 @@ internal class JsonDataSource : IEmissionsDataSource
         }
         using Stream stream = GetStreamFromFileLocation();
         var jsonObject = await JsonSerializer.DeserializeAsync<EmissionsJsonFile>(stream);
-        if (_emissionsData is null || !_emissionsData.Any())
+        if (_configuration.CacheJsonData && (_emissionsData is null || !_emissionsData.Any()))
         {
             _emissionsData = jsonObject?.Emissions;
         }
-        return _emissionsData;
+        return jsonObject?.Emissions;
     }
 
     private Stream GetStreamFromFileLocation()

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/test/CarbonAware.DataSources.Json.Tests.csproj
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.Json/test/CarbonAware.DataSources.Json.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-    <PackageReference Include="Moq"/>
-    <PackageReference Include="NUnit"/>
-    <PackageReference Include="NUnit3TestAdapter"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -23,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\mock\CarbonAware.DataSources.Json.Mocks.csproj" />
     <ProjectReference Include="..\src\CarbonAware.DataSources.Json.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
# Pull Request

## Summary

Support dynamic update for emission data JSON file.

It is useful if we can update emission data when we use custom data via JSON datasource.
Currently JSON datasource would cache all of data in JSON on memory, so the update would not propagate even if it is updated. We have to restart WebAPI when we need to update emission data. It is not good for system operation.

I want to introduce `CacheJsonData` into JSON datasource configuration. If the user set it to `false`, JSON datasource would read emission data JSON file everytime when the request happens. This option is set to `true` by default, so this PR does not break current behavior.

## Changes

- JSON datasource
- Test case for above
- Document for JSON datasource

## Checklist

- [x] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?
- [x] Added any new Tests?
- [x] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [x] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?

No

## Is this a breaking change?

No