### PR TITLE
Upgrade actions/{upload,download}-artifact

### DIFF
--- a/.github/workflows/1-pr.yaml
+++ b/.github/workflows/1-pr.yaml
@@ -188,7 +188,7 @@ jobs:
         with:
           name: dev-swagger.yaml
           path: src/CarbonAware.WebApi/src/wwwroot/api/v1/swagger.yaml
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: pr-swagger.yaml
           path: ./src/CarbonAware.WebApi/src/wwwroot/api/v1/pr-swagger.yaml

--- a/.github/workflows/1-pr.yaml
+++ b/.github/workflows/1-pr.yaml
@@ -128,7 +128,7 @@ jobs:
         working-directory: ./src/CarbonAware.WebApi/src 
       
       - name: Upload swagger artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: pr-swagger.yaml
           path: src/CarbonAware.WebApi/src/wwwroot/api/v1/swagger.yaml
@@ -184,7 +184,7 @@ jobs:
         env:
           DOTNET_ROLL_FORWARD: LatestMajor
       - name: Upload dev artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: dev-swagger.yaml
           path: src/CarbonAware.WebApi/src/wwwroot/api/v1/swagger.yaml

--- a/.github/workflows/2.a-deploy.yaml.ignore
+++ b/.github/workflows/2.a-deploy.yaml.ignore
@@ -28,7 +28,7 @@
 
 #     steps:
 #       - name: Download artifact from build job
-#         uses: actions/download-artifact@v2
+#         uses: actions/download-artifact@v4
 #         with:
 #           name: CarbonAwareApi
 

--- a/.github/workflows/dev_carbon-aware-api.yml
+++ b/.github/workflows/dev_carbon-aware-api.yml
@@ -32,7 +32,7 @@ jobs:
         run: dotnet publish -c Release -o ${{env.DOTNET_ROOT}}/myapp
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: CarbonAwareApi
           path: ${{env.DOTNET_ROOT}}/myapp

--- a/.github/workflows/dev_carbon-aware-api.yml
+++ b/.github/workflows/dev_carbon-aware-api.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: CarbonAwareApi
 


### PR DESCRIPTION
# Pull Request

Issue Number: #564

## Summary

Upgrade actions/upload-artifact and actions/download-artifact in GHA workflow.

See GitHub Blog for details: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

## Changes

- .github/workflows/1-pr.yaml
- .github/workflows/dev_carbon-aware-api.yml
- .github/workflows/2.a-deploy.yaml.ignore

All of lines in `2.a-deploy.yaml.ignore` are commented out, but I upgraded because this workflow might be enabled again in future.

One of actions/download-artifact in `1-pr.yaml` uses v3 (non-deprecated version), but I upgraded because I think it is better to use same version entire workflows.

## Checklist

- [ ] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [x] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?

No

## Is this a breaking change?

No

This PR Closes #564 
