### PR TITLE
EM datasource didn't filter out-of-range emission data

### DIFF
--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMaps/src/ElectricityMapsDataSource.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMaps/src/ElectricityMapsDataSource.cs
@@ -138,18 +138,18 @@ internal class ElectricityMapsDataSource : IForecastDataSource, IEmissionsDataSo
 
     private IEnumerable<EmissionsData> HistoryCarbonIntensityToEmissionsData(Location location, IEnumerable<CarbonIntensity> data, DateTimeOffset startTime, DateTimeOffset endTime)
     {
-        IEnumerable<EmissionsData> emissions;
         var duration = GetDurationFromHistoryDataPointsOrDefault(data, TimeSpan.Zero);
-        emissions = data.Select(d =>
-        {
-            var emission = (EmissionsData) d;
-            emission.Location = location.Name ?? string.Empty;
-            emission.Time = d.DateTime;
-            emission.Duration = duration;
-            return emission;
-        });
-
-        return emissions;
+        return data.Where(d => ((startTime <= d.DateTime) && (d.DateTime < endTime)) ||
+                               ((startTime <= d.DateTime.Add(duration)) && (d.DateTime.Add(duration) < endTime)) ||
+                               ((d.DateTime < startTime) && (endTime < d.DateTime.Add(duration))))
+            .Select(d =>
+            {
+                var emission = (EmissionsData)d;
+                emission.Location = location.Name ?? string.Empty;
+                emission.Time = d.DateTime;
+                emission.Duration = duration;
+                return emission;
+            });
     }
 
     private TimeSpan GetDurationFromHistoryDataPointsOrDefault(IEnumerable<CarbonIntensity> carbonIntensityDataPoints, TimeSpan defaultValue)

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMaps/test/ElectricityMapsDataSourceTests.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMaps/test/ElectricityMapsDataSourceTests.cs
@@ -134,6 +134,7 @@ class ElectricityMapsDataSourceTests
     public async Task GetCarbonIntensity_DateRangeWithin24Hours_ReturnsResultsWhenRecordsFound()
     {
         var startDate = DateTimeOffset.UtcNow.AddHours(-10);
+        var expectedDate = startDate.AddMinutes(-10);
         var endDate = startDate.AddHours(1);
         var expectedCarbonIntensity = 100;
 
@@ -145,10 +146,12 @@ class ElectricityMapsDataSourceTests
             {
                 new CarbonIntensity()
                 {
-                    Value = expectedCarbonIntensity,
+                    DateTime = startDate.AddMinutes(-40),  // out of range
+                    Value = 0,
                 },
                 new CarbonIntensity()
                 {
+                    DateTime = expectedDate,
                     Value = expectedCarbonIntensity,
                 }
             }
@@ -162,10 +165,11 @@ class ElectricityMapsDataSourceTests
         var result = await this._dataSource.GetCarbonIntensityAsync(new List<Location>() { _defaultLocation }, startDate, endDate);
 
         Assert.IsNotNull(result);
-        Assert.That(result.Count(), Is.EqualTo(2));
+        Assert.That(result.Count(), Is.EqualTo(1));
 
         var first = result.First();
         Assert.IsNotNull(first);
+        Assert.That(expectedDate, Is.EqualTo(first.Time));
         Assert.That(first.Rating, Is.EqualTo(expectedCarbonIntensity));
         Assert.That(first.Location, Is.EqualTo(_defaultLocation.Name));
 
@@ -176,6 +180,7 @@ class ElectricityMapsDataSourceTests
     public async Task GetCarbonIntensity_DateRangeMore24Hours_ReturnsResultsWhenRecordsFound()
     {
         var startDate = _defaultDataStartTime;
+        var expectedDate = startDate.AddMinutes(-10);
         var endDate = startDate.AddHours(1);
         var expectedCarbonIntensity = 100;
 
@@ -187,10 +192,12 @@ class ElectricityMapsDataSourceTests
             {
                 new CarbonIntensity()
                 {
-                    Value = expectedCarbonIntensity,
+                    DateTime = startDate.AddMinutes(-40),  // out of range
+                    Value = 0,
                 },
                 new CarbonIntensity()
                 {
+                    DateTime = expectedDate,
                     Value = expectedCarbonIntensity,
                 }
             }
@@ -206,10 +213,11 @@ class ElectricityMapsDataSourceTests
         var result = await this._dataSource.GetCarbonIntensityAsync(new List<Location>() { _defaultLocation }, startDate, endDate);
 
         Assert.IsNotNull(result);
-        Assert.That(result.Count(), Is.EqualTo(2));
+        Assert.That(result.Count(), Is.EqualTo(1));
 
         var first = result.First();
         Assert.IsNotNull(first);
+        Assert.That(expectedDate, Is.EqualTo(first.Time));
         Assert.That(first.Rating, Is.EqualTo(expectedCarbonIntensity));
         Assert.That(first.Location, Is.EqualTo(_defaultLocation.Name));
 
@@ -261,7 +269,9 @@ class ElectricityMapsDataSourceTests
         {
             HistoryData = new List<CarbonIntensity>()
             {
-                new CarbonIntensity()
+                new CarbonIntensity(){
+                    DateTime = startDate.AddMinutes(30),
+                },
             }
         };
 
@@ -285,7 +295,7 @@ class ElectricityMapsDataSourceTests
     {
         var startDate = DateTimeOffset.UtcNow.AddHours(-8);
         var endDate = startDate.AddHours(1);
-        var expectedDuration = TimeSpan.FromHours(1);
+        var expectedDuration = TimeSpan.FromMinutes(59);
         // Arrange
         _locationSource.Setup(l => l.ToGeopositionLocationAsync(_defaultLocation)).Returns(Task.FromResult(_defaultLocation));
 


### PR DESCRIPTION
# Pull Request

Issue Number: #570 

## Summary

bylocation query in EM datasource did not reagard with specified time range. See #570 for more details.

## Changes

- EM Datasource and testcase

## Checklist

- [x] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [x] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?

No

## Is this a breaking change?

Yes, SDK user would not see any out-of-range emission data, but it is correct behavior.

This PR Closes #570 
