### PR TITLE
Consider null value in carbonIntensity on EM

### DIFF
--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMaps/src/Model/HistoryCarbonIntensityData.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMaps/src/Model/HistoryCarbonIntensityData.cs
@@ -32,7 +32,7 @@ internal record CarbonIntensity
     /// Carbon Intensity value.
     /// </summary>
     [JsonPropertyName("carbonIntensity")]
-    public int Value { get; init; }
+    public int? Value { get; init; }
 
     /// <summary>
     /// Indicates the datetime of the carbon intensity
@@ -74,7 +74,7 @@ internal record CarbonIntensity
     {
         return new EmissionsData
         {
-            Rating = historyCarbonIntensity.Value,
+            Rating = historyCarbonIntensity.Value ?? -1,
             Time = historyCarbonIntensity.UpdatedAt,
         };
     }

--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMaps/test/Client/TestData.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.ElectricityMaps/test/Client/TestData.cs
@@ -92,4 +92,28 @@ internal static class TestData
 
         return json.ToString();
     }
+
+    public static string GetHistoryCarbonIntensityDataJsonStringWithNull()
+    {
+        var json = new JsonObject
+        {
+            ["zone"] = TestZoneId1,
+            ["history"] = new JsonArray
+            {
+                new JsonObject
+                {
+                    ["datetime"] = new DateTimeOffset(2099, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                    ["updatedAt"] = new DateTimeOffset(2099, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                    ["createdAt"] = new DateTimeOffset(2099, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                    ["carbonIntensity"] = null,
+                    ["emissionFactorType"] = "lifecycle",
+                    ["isEstimated"] = false,
+                    ["estimatedMethod"] = null,
+                }
+            }
+        };
+
+        return json.ToString();
+    }
+
 }


### PR DESCRIPTION
# Pull Request

Issue Number: #571 

## Summary

Consider null value(s) if it is returned from Electricity Maps.

This PR set `-1` to `HistoryCarbonIntensityData.Vaule` when `carbonIntensity` in response body from Electricity Maps is `null`. But I'm not sure it is ok because `-1` does not mean `null` - it might be ok it is documented. Or we can exclude it in filter phase in data source implementation. What do you think?

## Changes

- HistoryCarbonIntensityData.cs

## Checklist

- [x] Local Tests Passing?
- [ ] CICD and Pipeline Tests Passing?
- [x] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [x] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?

No

## Is this a breaking change?

No

This PR Closes #571
