### PR TITLE
Add gh cli to devcontainer/codespace

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,7 +32,9 @@
 
 	// Uncomment the line below to mount your local usersecrets into the devcontainer from a Mac/Linux OS
 	// "mounts": [ "source=${localEnv:HOME}/.microsoft/usersecrets,target=/root/.microsoft/usersecrets,type=bind" ],
-	
+	"features": {
+		"ghcr.io/devcontainers/features/github-cli:1": {}
+	},
 	
 	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"customizations": {


### PR DESCRIPTION
# Pull Request

## Summary

quick one to add the github cli to codespaces for this repository

## Changes

- Updated devcontainer.json to list github cli as a feature

## Checklist

- [ ] Local Tests Passing?
- [ ] CICD and Pipeline Tests Passing?

## Are there API Changes?

If yes, what are the expected API Changes? Please link to an API-Comparison
workflow with the API Diff.

## Is this a breaking change?

If yes, what workflow does this break?

## Anything else?

Other comments, collaborators, etc.

> Please follow
> [GitHub's suggested syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
> to link Pull Requests to Issues via keywords

This PR Closes #<issue_number>
