### PR TITLE
[URGENT] Set JsonStringConverter to JSON deserializer option in WattTimeClient

### DIFF
--- a/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/src/Client/WattTimeClient.cs
+++ b/src/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/src/Client/WattTimeClient.cs
@@ -10,13 +10,17 @@ using System.Net.Http.Headers;
 using System.Net.Mime;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Web;
 
 namespace CarbonAware.DataSources.WattTime.Client;
 
 internal class WattTimeClient : IWattTimeClient
 {
-    private static readonly JsonSerializerOptions _options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+    private static readonly JsonSerializerOptions _options = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter() }
+    };
 
     private static readonly HttpStatusCode[] _retriableStatusCodes = new HttpStatusCode[]
     {


### PR DESCRIPTION
# Pull Request

@vaughanknight @danuw Please review this PR. I think it is urgent bug.

## Summary

`co2_moer` and `co2_aoer` have been supported since #611 , however WattTime client is possibility not to work after this change.

#611 introduces these values as `enum`, not `stiring. It might cause deserialization error.

```
fail: CarbonAware.WebApi.Filters.HttpResponseExceptionFilter[0]
      Exception: The JSON value could not be converted to CarbonAware.DataSources.WattTime.Constants.SignalTypes. Path: $.signal_type | LineNumber: 0 | BytePositionInLine: 102.
      System.Text.Json.JsonException: The JSON value could not be converted to CarbonAware.DataSources.WattTime.Constants.SignalTypes. Path: $.signal_type | LineNumber: 0 | BytePositionInLine: 102.
         at System.Text.Json.ThrowHelper.ThrowJsonException(String message)
         at System.Text.Json.Serialization.Converters.EnumConverter`1.Read(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options)
         at System.Text.Json.Serialization.Metadata.JsonPropertyInfo`1.ReadJsonAndSetMember(Object obj, ReadStack& state, Utf8JsonReader& reader)
         at System.Text.Json.Serialization.Converters.ObjectDefaultConverter`1.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value)
         at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value, Boolean& isPopulatedValue)
         at System.Text.Json.Serialization.JsonConverter`1.ReadCore(Utf8JsonReader& reader, JsonSerializerOptions options, ReadStack& state)
         at System.Text.Json.Serialization.Metadata.JsonTypeInfo`1.ContinueDeserialize(ReadBufferState& bufferState, JsonReaderState& jsonReaderState, ReadStack& readStack)
         at System.Text.Json.Serialization.Metadata.JsonTypeInfo`1.DeserializeAsync(Stream utf8Json, CancellationToken cancellationToken)
         at CarbonAware.DataSources.WattTime.Client.WattTimeClient.<>c__DisplayClass34_0.<<GetRegionFromCacheAsync>b__0>d.MoveNext() in /app/CarbonAware.DataSources/CarbonAware.DataSources.WattTime/src/Client/WattTimeClient.cs:line 315 
```

WattTime respond as following in this case. It was expected.

```json
{
  "region": "CAISO",
  "region_full_name": "California Independent System Operator",
  "signal_type": "co2_aoer"
}
```

## Changes

- Set [JsonStringEnumConverter](https://learn.microsoft.com/en-us/dotnet/api/system.text.json.serialization.jsonstringenumconverter) to JSON deserializer option.

## Checklist

- [x] Local Tests Passing?
- [x] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [ ] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?

No

## Is this a breaking change?

No