### PR TITLE
Add datasource configuration into 1-pr.yaml

### DIFF
--- a/.github/workflows/1-pr.yaml
+++ b/.github/workflows/1-pr.yaml
@@ -184,6 +184,8 @@ jobs:
       - name: Generate Open API
         run: dotnet tool run swagger tofile --output ./wwwroot/api/v1/swagger.yaml --yaml ${{ env.DLL_FILE_PATH }} v1
         env:
+          DataSources__EmissionsDataSource: Json
+          DataSources__Configurations__Json__Type: JSON
           DOTNET_ROLL_FORWARD: LatestMajor
       - name: Upload dev artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
# Pull Request

## Summary

Add data source configuration into 1-pr.yaml .

CASDK requires data source configuration since #450 , so GitHub Actions workflow would fail because CASDK (for generating OpenAPI document) cannot start without it. We saw the error on #630 .

## Changes

- Add `DataSources__EmissionsDataSource` and `DataSources__Configurations__Json__Type` into 1-pr.yaml .

## Checklist

- [x] Local Tests Passing?
- [ ] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [x] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?

No

## Is this a breaking change?

No