### PR TITLE
Add environment variables for data source to GHA Workflows

### DIFF
--- a/.github/workflows/4.a.1-generate-webapi-client-java.yaml
+++ b/.github/workflows/4.a.1-generate-webapi-client-java.yaml
@@ -18,6 +18,9 @@ jobs:
         image: ${{ inputs.image }}
         ports:
           - 8080:8080
+        env:
+          DataSources__EmissionsDataSource: Json
+          DataSources__Configurations__Json__Type: JSON
         options: >-
           --health-cmd "curl -sS http://localhost:8080/health"
           --health-interval 3s

--- a/.github/workflows/4.a.1-generate-webapi-client-npm.yaml
+++ b/.github/workflows/4.a.1-generate-webapi-client-npm.yaml
@@ -18,6 +18,9 @@ jobs:
         image: ${{ inputs.image }}
         ports:
           - 8080:8080
+        env:
+          DataSources__EmissionsDataSource: Json
+          DataSources__Configurations__Json__Type: JSON
         options: >-
           --health-cmd "curl -sS http://localhost:8080/health"
           --health-interval 3s

--- a/.github/workflows/detect-webapi-version.yaml
+++ b/.github/workflows/detect-webapi-version.yaml
@@ -40,6 +40,9 @@ jobs:
         image: ${{ needs.make-image-name-for-pull.outputs.image }}
         ports:
           - 8080:8080
+        env:
+          DataSources__EmissionsDataSource: Json
+          DataSources__Configurations__Json__Type: JSON
         options: >-
           --health-cmd "curl -sS http://localhost:8080/health"
           --health-interval 3s


### PR DESCRIPTION
# Pull Request

## Summary

Add 2 environment variables (`DataSources__EmissionsDataSource` and `DataSources__Configurations__Json__Type`) to GHA workflows for generating WebAPI client libs.

We saw following error in GHA log for v1.8.0 release.

```
  /usr/bin/docker logs --details 5a00138dd0c4188bfe4d084772c7a9feeeacf8c3406dfc104a1aeee6e9cc7b20
   Unhandled exception. CarbonAware.Exceptions.ConfigurationException: No data sources are configured
      at CarbonAware.DataSources.Configuration.ServiceCollectionExtensions.AddDataSourceService(IServiceCollection services, IConfiguration configuration) in /app/CarbonAware.DataSources/CarbonAware.DataSources.Registration/Configuration/ServiceCollectionExtensions.cs:line 73
      at GSF.CarbonAware.Configuration.ServiceCollectionExtensions.AddEmissionsServices(IServiceCollection services, IConfiguration configuration) in /app/GSF.CarbonAware/src/Configuration/ServiceCollectionExtensions.cs:line 31
      at Program.<Main>$(String[] args) in /app/CarbonAware.WebApi/src/Program.cs:line 45
  Error: Failed to initialize container ghcr.io/green-software-foundation/carbon-aware-sdk:latest
Error: One or more containers failed to start.
```

It is caused by #450. We have to configure data source since this.

The error was occurred in `detect-webapi-version.yaml`, however I found same issue in both `4.a.1-generate-webapi-client-java.yaml` and `4.a.1-generate-webapi-client-npm.yaml`. So I also fix them in this PR.

## Changes

Add 2 environment variables to GHA service container.

## Checklist

- [ ] Local Tests Passing?
- [ ] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [x] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?

No

## Is this a breaking change?

No