### PR TITLE
Update WattTime sample API endpoints and request parameters

### DIFF
--- a/samples/watttime-registration/3-makerequest.py
+++ b/samples/watttime-registration/3-makerequest.py
@@ -3,18 +3,19 @@ from requests.auth import HTTPBasicAuth
 from settings import *
 from datetime import date
 
-login_url = 'https://api2.watttime.org/v2/login'
+login_url = 'https://api.watttime.org/login'
 token = requests.get(login_url, auth=HTTPBasicAuth(wt_username, wt_password)).json()['token']
 
-data_url = 'https://api2.watttime.org/v2/data'
+data_url = 'https://api.watttime.org/v3/historical'
 headers = {'Authorization': 'Bearer {}'.format(token)}
 
 last_year = str(date.today().year - 1)
 starttime = last_year + '-02-20T16:00:00-0800'
 endtime   = last_year + '-02-20T16:15:00-0800'
 
-params = {'ba': 'CAISO_NORTH', 
-          'starttime': starttime, 
-          'endtime': endtime}
+params = {'region': 'CAISO_NORTH', 
+          'signal_type': 'co2_moer',
+          'start': starttime, 
+          'end': endtime}
 rsp = requests.get(data_url, headers=headers, params=params)
 print(rsp.text)


### PR DESCRIPTION
WattTime API access has changed since the initial implementation

# Pull Request

Issue Number: (Link to Github Issue or Azure Dev Ops Task/Story)

## Summary

The WattTime API no longer supports the v2/data endpoint, ref: https://docs.watttime.org/

## Changes

- Update implementation for sample WattTime code

## Checklist

- [ ] Local Tests Passing?
- [ ] CICD and Pipeline Tests Passing?
- [ ] Added any new Tests?
- [ ] Documentation Updates Made?
- [ ] Are there any API Changes? If yes, please describe below.
- [x] This is not a breaking change. If it is, please describe it below.

## Are there API Changes?

No

## Is this a breaking change?

No

## Anything else?

Other comments, collaborators, etc.

> Please follow
> [GitHub's suggested syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
> to link Pull Requests to Issues via keywords

This PR Closes #<issue_number>
